### PR TITLE
Parallelize export

### DIFF
--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_main.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_main.f90
@@ -41,6 +41,9 @@ program wfcExportVASPMain
 
   endif
 
+  call MPI_BCAST(exportDir, len(trim(exportDir)), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(VASPDir, len(trim(VASPDir)), MPI_CHARACTER, root, worldComm, ierr)
+
   if (ionode) write(iostd,*) "Reading WAVECAR"
 
   call readWAVECAR(VASPDir, realSpaceLatticeVectors, recipSpaceLatticeVectors, wfcECut, bandOccupation, omega, wfcVecCut, &

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_main.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_main.f90
@@ -41,8 +41,8 @@ program wfcExportVASPMain
 
   endif
 
-  call MPI_BCAST(exportDir, len(trim(exportDir)), MPI_CHARACTER, root, worldComm, ierr)
-  call MPI_BCAST(VASPDir, len(trim(VASPDir)), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(exportDir, len(exportDir), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(VASPDir, len(VASPDir), MPI_CHARACTER, root, worldComm, ierr)
 
   if (ionode) write(iostd,*) "Reading WAVECAR"
 

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
@@ -1075,6 +1075,8 @@ module wfcExportVASPMod
           nPWs1kGlobal(ik) = nint(nPWs1kGlobal_real)
 
           irec = irec + nBands
+            ! Skip the records for the plane-wave coefficients for now.
+            ! Those are read in the `readAndWriteWavefunction` subroutine.
 
         enddo
       enddo
@@ -1179,10 +1181,14 @@ module wfcExportVASPMod
         ionode_k_id = mod(ik+(isp-1)*nKpoints, nProcs)
         ionode_k = myid == ionode_k_id
           ! Determine if this process is the node responsible
-          ! for outputting data for this k-point
+          ! for outputting data for this k-point. K-points are 
+          ! distributed across processes in a round-robin fashion.
 
 
         irec = irec + 1
+          ! Have all processes increment the record number so
+          ! they know where they are supposed to access the file
+          ! once/if they are the `ionode_k`
        
         if(ionode_k) then
           call int2str(ik+(isp-1)*nKPoints, indexC)

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
@@ -649,9 +649,9 @@ module wfcExportVASPMod
       !! Full WAVECAR file name including path
 
     
-    fileName = trim(VASPDir)//'/WAVECAR'
-
     if(ionode) then
+
+      fileName = trim(VASPDir)//'/WAVECAR'
 
       nRecords = 24
         ! Set a starting value for the number of records

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
@@ -649,9 +649,7 @@ module wfcExportVASPMod
       !! Full WAVECAR file name including path
 
     
-    !fileName = trim(VASPDir)//'/WAVECAR'
-    fileName = '../WAVECAR'
-      !! Hardcode file name for now until figure out how to broadcast 
+    fileName = trim(VASPDir)//'/WAVECAR'
 
     if(ionode) then
 

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
@@ -1199,7 +1199,6 @@ module wfcExportVASPMod
             ! Open `wfc.ik` file to write plane wave coefficients
             !! Hardcode for now until figure out how to broadcast
 
-          write(wfcOutUnit, '("# Node : ",i10)') myid
           write(wfcOutUnit, '("# Spin : ",i10, " Format: ''(a9, i10)''")') isp
           write(wfcOutUnit, '("# Complex : wavefunction coefficients (a.u.)^(-3/2). Format: ''(2ES24.15E3)''")')
             ! Write header to `wfc.ik` file

--- a/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
+++ b/Export/VASP/FromVASPOutput/src/Export_FromVASPOutput_module.f90
@@ -1042,9 +1042,7 @@ module wfcExportVASPMod
     allocate(nPWs1kGlobal(nKPoints))
     allocate(eigenE(nSpins,nKPoints,nBands))
     
-    !fileName = trim(VASPDir)//'/WAVECAR'
-    fileName = '../WAVECAR'
-      !! Hardcode file name for now until figure out how to broadcast 
+    fileName = trim(VASPDir)//'/WAVECAR'
 
     if(ionode) then
       open(unit=wavecarUnit, file=fileName, access='direct', recl=nRecords, iostat=ierr, status='old')
@@ -1160,9 +1158,7 @@ module wfcExportVASPMod
       allocate(coeff(1,1))
     endif
     
-    !fileName = trim(VASPDir)//'/WAVECAR'
-    fileName = '../WAVECAR'
-      !! Hardcode file name for now until figure out how to broadcast 
+    fileName = trim(VASPDir)//'/WAVECAR'
 
     open(unit=wavecarUnit, file=fileName, access='direct', recl=nRecords, iostat=ierr, status='old', SHARED)
     if (ierr .ne. 0) write(iostd,*) 'open error - iostat =', ierr
@@ -1194,8 +1190,7 @@ module wfcExportVASPMod
           call int2str(ik+(isp-1)*nKPoints, indexC)
 
           wfcOutUnit = 83 + ionode_k_id
-          !open(wfcOutUnit, file=trim(exportDir)//"/wfc."//trim(indexC))
-          open(wfcOutUnit, file="wfc."//trim(indexC))
+          open(wfcOutUnit, file=trim(exportDir)//"/wfc."//trim(indexC))
             ! Open `wfc.ik` file to write plane wave coefficients
             !! Hardcode for now until figure out how to broadcast
 


### PR DESCRIPTION
Parallelize the output of `wfc.ik` files. Each k-point is assigned to a process in round-robin fashion. Parallelization is only over k-points.