### PR TITLE
Resolve export discrepancies

### DIFF
--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -68,8 +68,11 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call read_vasprun_xml(realLattVec, nKPoints, VASPDir, atomPositionsDir, eFermi, kWeight, fftGridSize, iType, nAtoms, nAtomsEachType, nAtomTypes)
+  call read_vasprun_xml(realLattVec, nKPoints, VASPDir, eFermi, kWeight, fftGridSize, iType, nAtoms, nAtomsEachType, nAtomTypes)
     !! * Read the k-point weights and cell info from the `vasprun.xml` file
+
+  call readCONTCAR(nAtoms, VASPDir, atomPositionsDir)
+    !! * Get coordinates from CONTCAR
 
 
   call distributeItemsInSubgroups(myPoolId, nKPoints, nProcs, nProcPerPool, nPools, ikStart_pool, ikEnd_pool, nkPerPool)

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -57,7 +57,7 @@ program wfcExportVASPMain
 
 
   call readWAVECAR(VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
-      kPosition, nBands, nKPoints, nPWs1kGlobal, nRecords, nSpins, eigenE)
+      kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nRecords, nSpins, eigenE)
     !! * Read cell and wavefunction data from the WAVECAR file
 
 
@@ -68,7 +68,7 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call read_vasprun_xml(realLattVec, nKPoints, VASPDir, eFermi, kWeight, fftGridSize, iType, nAtoms, nAtomsEachType, nAtomTypes)
+  call read_vasprun_xml(realLattVec, nKPoints, VASPDir, eFermi, kWeight, iType, nAtoms, nAtomsEachType, nAtomTypes)
     !! * Read the k-point weights and cell info from the `vasprun.xml` file
 
   call readCONTCAR(nAtoms, VASPDir, atomPositionsDir)
@@ -129,7 +129,7 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call projAndWav(fftGridSize, maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
+  call projAndWav(maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
       nRecords, nSpins, gKIndexOrigOrderLocal, gKSort, gVecMillerIndicesGlobal, nPWs1kGlobal, atomPositionsDir, kPosition, omega, &
       recipLattVec, exportDir, VASPDir, gammaOnly, pot)
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -4203,7 +4203,7 @@ module wfcExportVASPMod
     character(len=300) :: ikC, ispC, ibgrpC, nbgrpC
       !! Character index
 
-    complex*8 :: projection, projectionLocal
+    complex(kind=dp) :: projection, projectionLocal
       !! Projection for current atom/band/lm channel
 
 
@@ -4236,7 +4236,7 @@ module wfcExportVASPMod
               ! Don't need to worry about sorting because projection
               ! has sum over plane waves.
 
-            call MPI_ALLREDUCE(projectionLocal, projection, 1, MPI_COMPLEX, MPI_SUM, intraBgrpComm, ierr)
+            call MPI_ALLREDUCE(projectionLocal, projection, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, intraBgrpComm, ierr)
 
             if(indexInBgrp == 0) write(projOutUnit,'(2ES24.15E3)') projection
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -4242,6 +4242,9 @@ module wfcExportVASPMod
 
           enddo
         enddo
+
+        iaBase = iaBase + nAtomsEachType(iT)
+
       enddo
     enddo
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -3894,8 +3894,7 @@ module wfcExportVASPMod
 
         fNameProc = trim(fNameBase)//"."//trim(iprocC)
 
-        call execute_command_line('cat '//trim(fNameProc)//' >> '//trim(fNameBase))
-        call execute_command_line('rm '//trim(fNameProc))
+        call execute_command_line('cat '//trim(fNameProc)//' >> '//trim(fNameBase)//' && rm '//trim(fNameProc))
 
       enddo
 
@@ -4085,8 +4084,7 @@ module wfcExportVASPMod
 
         fNameBgrp = trim(fNameBase)//"."//trim(ibgrpC)
 
-        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase))
-        call execute_command_line('rm '//trim(fNameBgrp))
+        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase)//'&& rm '//trim(fNameBgrp))
 
       enddo
 
@@ -4227,8 +4225,7 @@ module wfcExportVASPMod
 
         fNameBgrp = trim(fNameBase)//"."//trim(ibgrpC)
 
-        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase))
-        call execute_command_line('rm '//trim(fNameBgrp))
+        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase)//'&& rm '//trim(fNameBgrp))
 
 
       enddo

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -3810,9 +3810,9 @@ module wfcExportVASPMod
     complex(kind=dp) :: phaseExpGlobal(nPWs1k, nAtoms)
       !! Exponential phase factor
 
-    character(len=300) :: ikC, iprocC
+    character(len=300) :: ikC, iprocC, procNumC
       !! Character index
-    character(len=300) :: fNameBase, fNameProc
+    character(len=300) :: fNameBase
       !! File names
 
 
@@ -3940,15 +3940,12 @@ module wfcExportVASPMod
 
       close(projOutUnit)
 
-      do iproc = 0, nProcPerBgrp-1
 
-        call int2str(iproc, iprocC)
+      call int2str(nProcPerBgrp-1, procNumC)
 
-        fNameProc = trim(fNameBase)//"."//trim(iprocC)
-
-        call execute_command_line('cat '//trim(fNameProc)//' >> '//trim(fNameBase)//' && rm '//trim(fNameProc))
-
-      enddo
+      !> Merge all of the individual-processor files and delete
+      call execute_command_line('cat '//trim(fNameBase)//'.{0..'//trim(procNumC)//'} >> '//trim(fNameBase)//&
+                                ' && rm '//trim(fNameBase)//'.{0..'//trim(procNumC)//'}')
 
     endif
 
@@ -4023,7 +4020,7 @@ module wfcExportVASPMod
 
     character(len=300) :: fNameBase, fNameBgrp
       !! File names for merging output
-    character(len=300) :: ikC, ispC, ibgrpC
+    character(len=300) :: ikC, ispC, ibgrpC, nbgrpC
       !! Character index
 
 
@@ -4129,16 +4126,14 @@ module wfcExportVASPMod
 
       close(wfcOutUnit)
         ! Close `wfc.isp.ik.myBgrpId` file
+      
 
-      do ibgrp = 0, nBandGroups-1
+      call int2str(nBandGroups-1, nbgrpC)
 
-        call int2str(ibgrp, ibgrpC)
+      !> Merge all of the individual-processor files and delete
+      call execute_command_line('cat '//trim(fNameBase)//'.{0..'//trim(nbgrpC)//'} >> '//trim(fNameBase)//&
+                                ' && rm '//trim(fNameBase)//'.{0..'//trim(nbgrpC)//'}')
 
-        fNameBgrp = trim(fNameBase)//"."//trim(ibgrpC)
-
-        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase)//'&& rm '//trim(fNameBgrp))
-
-      enddo
 
     endif
 
@@ -4205,7 +4200,7 @@ module wfcExportVASPMod
 
     character(len=300) :: fNameBase, fNameBgrp
       !! Character index
-    character(len=300) :: ikC, ispC, ibgrpC
+    character(len=300) :: ikC, ispC, ibgrpC, nbgrpC
       !! Character index
 
     complex*8 :: projection, projectionLocal
@@ -4271,16 +4266,11 @@ module wfcExportVASPMod
 
       close(projOutUnit)
 
-      do ibgrp = 0, nBandGroups-1
+      call int2str(nBandGroups-1, nbgrpC)
 
-        call int2str(ibgrp, ibgrpC)
-
-        fNameBgrp = trim(fNameBase)//"."//trim(ibgrpC)
-
-        call execute_command_line('cat '//trim(fNameBgrp)//' >> '//trim(fNameBase)//'&& rm '//trim(fNameBgrp))
-
-
-      enddo
+      !> Merge all of the individual-processor files and delete
+      call execute_command_line('cat '//trim(fNameBase)//'.{0..'//trim(nbgrpC)//'} >> '//trim(fNameBase)//&
+                                ' && rm '//trim(fNameBase)//'.{0..'//trim(nbgrpC)//'}')
 
     endif
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -107,8 +107,6 @@ module wfcExportVASPMod
   complex*16, allocatable :: eigenE(:,:,:)
     !! Band eigenvalues
   
-  integer :: fftGridSize(3)
-    !! Number of points on the FFT grid in each direction
   integer, allocatable :: gIndexLocalToGlobal(:)
     !! Converts local index `ig` to global index
   integer, allocatable :: gKIndexLocalToGlobal(:,:)
@@ -128,12 +126,14 @@ module wfcExportVASPMod
   integer, allocatable :: gKSort(:,:)
     !! Indices to recover sorted order on reduced
     !! \(G+k\) grid
+  integer, allocatable :: gVecMillerIndicesGlobal(:,:)
+    !! Integer coefficients for G-vectors on all processors
   integer, allocatable :: iMill(:)
     !! Indices of miller indices after sorting
   integer, allocatable :: iType(:)
     !! Atom type index
-  integer, allocatable :: gVecMillerIndicesGlobal(:,:)
-    !! Integer coefficients for G-vectors on all processors
+  integer :: fftGridSize(3)
+    !! Max number of points on the FFT grid in each direction
   integer :: nAtoms
     !! Number of atoms
   integer :: nBands
@@ -788,7 +788,7 @@ module wfcExportVASPMod
 
 !----------------------------------------------------------------------------
   subroutine readWAVECAR(VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
-        kPosition, nBands, nKPoints, nPWs1kGlobal, nRecords, nSpins, eigenE)
+        kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nRecords, nSpins, eigenE)
     !! Read cell and wavefunction data from the WAVECAR file
     !!
     !! <h2>Walkthrough</h2>
@@ -815,6 +815,8 @@ module wfcExportVASPMod
     real(kind=dp), allocatable, intent(out) :: kPosition(:,:)
       !! Position of k-points in reciprocal space
 
+    integer, intent(out) :: fftGridSize(3)
+      !! Max number of points on the FFT grid in each direction
     integer, intent(out) :: nBands
       !! Total number of bands
     integer, intent(out) :: nKPoints
@@ -903,6 +905,9 @@ module wfcExportVASPMod
         !! * Calculate the reciprocal lattice vectors from the real-space
         !!   lattice vectors and the cell volume
 
+      call estimateMaxNumPlanewaves(recipLattVec, wfcECut*eVToRy, fftGridSize)
+        !! * Get the maximum number of plane waves
+
       !> * Write out total number of k-points, number of bands, 
       !>   the energy cutoff, the real-space-lattice vectors,
       !>   the cell volume, and the reciprocal lattice vectors
@@ -944,6 +949,7 @@ module wfcExportVASPMod
     call MPI_BCAST(nBands, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(wfcVecCut, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
     call MPI_BCAST(omega, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+    call MPI_BCAST(fftGridSize, 3, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(realLattVec, size(realLattVec), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
     call MPI_BCAST(recipLattVec, size(recipLattVec), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
@@ -1018,6 +1024,119 @@ module wfcExportVASPMod
 
     return
   end subroutine getReciprocalVectors
+
+!----------------------------------------------------------------------------
+  subroutine estimateMaxNumPlanewaves(recipLattVec, wfcECut, fftGridSize)
+    !! Get the maximum number of plane waves. I'm not sure how 
+    !! this is done completely. It seems to be just basic vector
+    !! stuff, but I haven't been able to make sense of it.
+    !! 
+    !! @todo Figure out how `estimateMaxNumPlanewaves` works @endtodo
+    !!
+    !! <h2>Walkthrough</h2>
+    !!
+
+    implicit none
+
+    ! Input variables:
+    real(kind=dp), intent(in) :: recipLattVec(3,3)
+      !! Reciprocal lattice vectors
+    real(kind=dp), intent(in) :: wfcECut
+      !! Plane wave energy cutoff in Ry
+
+    ! Output variables:
+    integer, intent(out) :: fftGridSize(3)
+      !! Max number of points on the FFT grid in each direction
+
+    ! Local variables:
+    real(kind=dp) :: b1mag, b2mag, b3mag
+      !! Reciprocal vector magnitudes
+    real(kind=dp) :: c = 0.26246582250210965422
+      !! \(2m/\hbar^2\) converted from J\(^{-1}\)m\(^{-2}\)
+      !! to eV\(^{-1}\)A\(^{-2}\)
+    real(kind=dp) :: phi12, phi13, phi23
+      !! Angle between vectors
+    real(kind=dp) :: sinphi123
+      !! \(\sin\phi_{123}\)
+    real(kind=dp) :: vmag
+      !! Magnitude of temporary vector
+    real(kind=dp) :: vtmp(3)
+      !! Temporary vector for calculating angles
+
+    integer :: nb1max, nb2max, nb3max
+      !! Max magnitude of G-vectors in each direction
+    integer :: nb1maxA, nb2maxA, nb3maxA
+      !! First estimate of max
+    integer :: nb1maxB, nb2maxB, nb3maxB
+      !! Second estimate of max
+    integer :: nb1maxC, nb2maxC, nb3maxC
+      !! Third estimate of max
+
+
+    b1mag = sqrt(sum(recipLattVec(:,1)**2))
+    b2mag = sqrt(sum(recipLattVec(:,2)**2))
+    b3mag = sqrt(sum(recipLattVec(:,3)**2))
+
+    write(iostd,*) 'reciprocal lattice vector magnitudes:'
+    write(iostd,*) sngl(b1mag),sngl(b2mag),sngl(b3mag)
+      !! * Calculate and output reciprocal vector magnitudes
+
+
+    phi12 = acos(sum(recipLattVec(:,1)*recipLattVec(:,2))/(b1mag*b2mag))
+      !! * Calculate angle between \(b_1\) and \(b_2\)
+
+    call vcross(recipLattVec(:,1), recipLattVec(:,2), vtmp)
+    vmag = sqrt(sum(vtmp(:)**2))
+    sinphi123 = sum(recipLattVec(:,3)*vtmp(:))/(vmag*b3mag)
+      !! * Get \(\sin\phi_{123}\)
+
+    nb1maxA = (dsqrt(wfcECut/eVToRy*c)/(b1mag*abs(sin(phi12)))) + 1
+    nb2maxA = (dsqrt(wfcECut/eVToRy*c)/(b2mag*abs(sin(phi12)))) + 1
+    nb3maxA = (dsqrt(wfcECut/eVToRy*c)/(b3mag*abs(sinphi123))) + 1
+      !! * Get first set of max values
+
+
+    phi13 = acos(sum(recipLattVec(:,1)*recipLattVec(:,3))/(b1mag*b3mag))
+      !! * Calculate angle between \(b_1\) and \(b_3\)
+
+    call vcross(recipLattVec(:,1), recipLattVec(:,3), vtmp)
+    vmag = sqrt(sum(vtmp(:)**2))
+    sinphi123 = sum(recipLattVec(:,2)*vtmp(:))/(vmag*b2mag)
+      !! * Get \(\sin\phi_{123}\)
+
+    nb1maxB = (dsqrt(wfcECut/eVToRy*c)/(b1mag*abs(sin(phi13)))) + 1
+    nb2maxB = (dsqrt(wfcECut/eVToRy*c)/(b2mag*abs(sinphi123))) + 1
+    nb3maxB = (dsqrt(wfcECut/eVToRy*c)/(b3mag*abs(sin(phi13)))) + 1
+      !! * Get first set of max values
+
+
+    phi23 = acos(sum(recipLattVec(:,2)*recipLattVec(:,3))/(b2mag*b3mag))
+      !! * Calculate angle between \(b_2\) and \(b_3\)
+
+    call vcross(recipLattVec(:,2), recipLattVec(:,3), vtmp)
+    vmag = sqrt(sum(vtmp(:)**2))
+    sinphi123 = sum(recipLattVec(:,1)*vtmp(:))/(vmag*b1mag)
+      !! * Get \(\sin\phi_{123}\)
+
+    nb1maxC = (dsqrt(wfcECut/eVToRy*c)/(b1mag*abs(sinphi123))) + 1
+    nb2maxC = (dsqrt(wfcECut/eVToRy*c)/(b2mag*abs(sin(phi23)))) + 1
+    nb3maxC = (dsqrt(wfcECut/eVToRy*c)/(b3mag*abs(sin(phi23)))) + 1
+      !! * Get first set of max values
+
+
+    nb1max = max0(nb1maxA,nb1maxB,nb1maxC)
+    nb2max = max0(nb2maxA,nb2maxB,nb2maxC)
+    nb3max = max0(nb3maxA,nb3maxB,nb3maxC)
+
+    fftGridSize(1) = 2*nb1max + 1
+    fftGridSize(2) = 2*nb2max + 1
+    fftGridSize(3) = 2*nb3max + 1
+
+    write(iostd,*) 'max. no. G values; 1,2,3 =', nb1max, nb2max, nb3max
+    write(iostd,*) ' '
+
+    return
+  end subroutine estimateMaxNumPlanewaves
 
 !----------------------------------------------------------------------------
   subroutine vcross(vec1, vec2, crossProd)
@@ -1214,7 +1333,7 @@ module wfcExportVASPMod
   end subroutine distributeBandsInGroups
 
 !----------------------------------------------------------------------------
-  subroutine read_vasprun_xml(realLattVec, nKPoints, VASPDir, eFermi, kWeight, fftGridSize, iType, nAtoms, nAtomsEachType, nAtomTypes)
+  subroutine read_vasprun_xml(realLattVec, nKPoints, VASPDir, eFermi, kWeight, iType, nAtoms, nAtomsEachType, nAtomTypes)
     !! Read the k-point weights and cell info from the `vasprun.xml` file
     !!
     !! <h2>Walkthrough</h2>
@@ -1239,8 +1358,6 @@ module wfcExportVASPMod
     real(kind=dp), allocatable, intent(out) :: kWeight(:)
       !! K-point weights
 
-    integer, intent(out) :: fftGridSize(3)
-      !! Number of points on the FFT grid in each direction
     integer, allocatable, intent(out) :: iType(:)
       !! Atom type index
     integer, intent(out) :: nAtoms
@@ -1348,26 +1465,6 @@ module wfcExportVASPMod
       found = .false.
       do while (.not. found)
         !! * Ignore everything until you get to a
-        !!   line with `'grids'`, indicating the
-        !!   tag surrounding the k-point weights
-        
-        read(57, '(A)') line
-
-        if (index(line,'grids') /= 0) found = .true.
-        
-      enddo
-
-      do ix = 1, 3
-        !! * Read in the FFT grid size in each direction
-
-        read(57,'(a28,i6,a4)') cDum, fftGridSize(ix), cDum
-
-      enddo
-
-
-      found = .false.
-      do while (.not. found)
-        !! * Ignore everything until you get to a
         !!   line with `'ORBITALMAG'`, indicating the
         !!   tag that determines if can ignore `VKPT_SHIFT`
         
@@ -1462,7 +1559,6 @@ module wfcExportVASPMod
     endif
 
     call MPI_BCAST(kWeight, size(kWeight), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-    call MPI_BCAST(fftGridSize, size(fftGridSize), MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(nAtomTypes, 1, MPI_INTEGER, root, worldComm, ierr)
 
@@ -1628,7 +1724,7 @@ module wfcExportVASPMod
 
     ! Input variables:
     integer, intent(in) :: fftGridSize(3)
-      !! Number of points on the FFT grid in each direction
+      !! Max number of points on the FFT grid in each direction
 
     real(kind=dp), intent(in) :: recipLattVec(3,3)
       !! Reciprocal lattice vectors
@@ -1664,7 +1760,7 @@ module wfcExportVASPMod
       !! Integer coefficients for G-vectors
     integer :: millX, millY, millZ
       !! Miller indices for each direction; in order
-      !! 0,1,...,(fftGridSize(:)/2),-(fftGridSize(:)/2-1),...,-1
+      !! 0,1,...,((fftGridSize(:)-1)/2),-((fftGridSize(:)-1)/2-1),...,-1
     integer :: npmax
       !! Max number of plane waves
 
@@ -1686,19 +1782,19 @@ module wfcExportVASPMod
 
         millZ = igz - 1
 
-        if (igz - 1 .gt. fftGridSize(3)/2) millZ = igz - 1 - fftGridSize(3)
+        if (igz - 1 .gt. (fftGridSize(3)-1)/2) millZ = igz - 1 - fftGridSize(3)
 
         do igy = 1, fftGridSize(2)
 
           millY = igy - 1
 
-          if (igy - 1 .gt. fftGridSize(2)/2) millY = igy - 1 - fftGridSize(2)
+          if (igy - 1 .gt. (fftGridSize(2)-1)/2) millY = igy - 1 - fftGridSize(2)
 
           do igx = 1, fftGridSize(1)
 
             millX = igx - 1
 
-            if (igx - 1 .gt. fftGridSize(1)/2) millX = igx - 1 - fftGridSize(1)
+            if (igx - 1 .gt. (fftGridSize(1)-1)/2) millX = igx - 1 - fftGridSize(1)
 
             nGVecsGlobal = nGVecsGlobal + 1
 
@@ -2900,7 +2996,7 @@ module wfcExportVASPMod
   end subroutine readPOTCAR
 
 !----------------------------------------------------------------------------
-  subroutine projAndWav(fftGridSize, maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
+  subroutine projAndWav(maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
       nRecords, nSpins, gKIndexOrigOrderLocal, gKSort, gVecMillerIndicesGlobal, nPWs1kGlobal, atomPositionsDir, kPosition, omega, &
       recipLattVec, exportDir, VASPDir, gammaOnly, pot)
 
@@ -2909,8 +3005,6 @@ module wfcExportVASPMod
     implicit none
 
     ! Input variables: 
-    integer, intent(in) :: fftGridSize(3)
-      !! Number of points on the FFT grid in each direction
     integer, intent(in) :: maxGkVecsLocal
       !! Max number of G+k vectors across all k-points
       !! in this pool
@@ -3045,7 +3139,7 @@ module wfcExportVASPMod
       call cpu_time(t1)
 
 
-      if(myBgrpId == 0) call calculateRealProjWoPhase(fftGridSize, ikLocal, nAtomTypes, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, &
+      if(myBgrpId == 0) call calculateRealProjWoPhase(ikLocal, nAtomTypes, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, &
                 gVecMillerIndicesGlobal, kPosition, omega, recipLattVec, gammaOnly, pot, realProjWoPhase, compFact)
 
       call MPI_BCAST(realProjWoPhase, size(realProjWoPhase), MPI_DOUBLE_PRECISION, 0, interBgrpComm, ierr)
@@ -3180,13 +3274,11 @@ module wfcExportVASPMod
   end subroutine calculatePhase
 
 !----------------------------------------------------------------------------
-  subroutine calculateRealProjWoPhase(fftGridSize, ik, nAtomTypes, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, &
+  subroutine calculateRealProjWoPhase(ik, nAtomTypes, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, &
       kPosition, omega, recipLattVec, gammaOnly, pot, realProjWoPhase, compFact)
     implicit none
 
     ! Input variables:
-    integer, intent(in) :: fftGridSize(3)
-      !! Number of points on the FFT grid in each direction
     integer, intent(in) :: ik
       !! Current k-point 
     integer, intent(in) :: nAtomTypes
@@ -3262,7 +3354,7 @@ module wfcExportVASPMod
       !! Spherical harmonics
 
 
-    call generateGridTable(fftGridSize, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, ik, kPosition, &
+    call generateGridTable(nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, ik, kPosition, &
           recipLattVec, gammaOnly, gkMod, gkUnit, multFact)
 
     YDimL = maxL(nAtomTypes, pot)
@@ -3351,13 +3443,11 @@ module wfcExportVASPMod
   end subroutine calculateRealProjWoPhase
 
 !----------------------------------------------------------------------------
-  subroutine generateGridTable(fftGridSize, nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, ik, kPosition, &
+  subroutine generateGridTable(nGkVecsLocal_ik, nKPoints, gKIndexOrigOrderLocal_ik, gVecMillerIndicesGlobal, ik, kPosition, &
         recipLattVec, gammaOnly, gkMod, gkUnit, multFact)
     implicit none
 
     ! Input variables:
-    integer, intent(in) :: fftGridSize(3)
-      !! Number of points on the FFT grid in each direction
     integer, intent(in) :: nGkVecsLocal_ik
       !! Local number of G-vectors on this processor
       !! for a given k-point

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -2797,11 +2797,11 @@ module wfcExportVASPMod
             
             read(potcarUnit,'(1X,A1)') charSwitch
             if (charSwitch /= 'p') call exitError('readPOTCAR', 'expected pseudowavefunction section', 1)
-            read(potcarUnit,*) (pot(iT)%wps(i,ip), i=1,pot(iT)%nmax)
+            read(potcarUnit,*) (pot(iT)%wps(ip,i), i=1,pot(iT)%nmax)
 
             read(potcarUnit,'(1X,A1)') charSwitch
             if (charSwitch /= 'a') call exitError('readPOTCAR', 'expected aewavefunction section', 1)
-            read(potcarUnit,*) (pot(iT)%wae(i,ip), i=1,pot(iT)%nmax)
+            read(potcarUnit,*) (pot(iT)%wae(ip,i), i=1,pot(iT)%nmax)
 
           enddo
 
@@ -4634,7 +4634,7 @@ module wfcExportVASPMod
         write(mainOutFileUnit, '("# AE, PS radial wfc for each beta function. Format: ''(2ES24.15E3)''")')
         do ip = 1, pot(iT)%nChannels
           do ir = 1, pot(iT)%nmax
-            write(mainOutFileUnit, '(2ES24.15E3)') pot(iT)%wae(ir,ip), pot(iT)%wps(ir,ip)
+            write(mainOutFileUnit, '(2ES24.15E3)') pot(iT)%wae(ip,ir), pot(iT)%wps(ip,ir)
           enddo
         enddo
       

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -27,7 +27,14 @@ program transitionMatrixElements
     !! Initialize MPI
   
   if(ionode) call cpu_time(t0)
-    
+
+
+  if(ionode) &
+    write(*, '("Pre-k-loop: [ ] Read inputs  [ ] Read full PW grid ")') &
+          ikGlobal
+    call cpu_time(t1)
+
+
   call readInput(maxGIndexGlobal, nKPoints, nGVecsGlobal, realLattVec, recipLattVec)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
@@ -41,9 +48,18 @@ program transitionMatrixElements
           iGEnd_pool, nGVecsLocal)
     !! * Distribute G-vectors across processes in pool
 
+
+  call cpu_time(t2)
+  if(ionode) write(*, '("Pre-k-loop: [X] Read inputs  [ ] Read full PW grid (",f10.2," secs)")') t2-t1
+  call cpu_time(t1)
+
   allocate(mill_local(3,nGVecsLocal))
 
   call getFullPWGrid(iGStart_pool, iGEnd_pool, nGVecsLocal, nGVecsGlobal, mill_local)
+
+  
+  call cpu_time(t2)
+  if(ionode) write(*, '("Pre-k-loop: [X] Read inputs  [X] Read full PW grid (",f10.2," secs)")') t2-t1
     
 
   if(indexInPool == 0) allocate(eigvI(iBandIinit:iBandIfinal), eigvF(iBandFinit:iBandFfinal))
@@ -107,7 +123,7 @@ program transitionMatrixElements
 
       call cpu_time(t2)
       if(indexInPool == 0) &
-        write(*, '("Pre-spin-loop for k-point",i4,": [X] Read grid  [X] Read projectors (",f10.2," secs)")') &
+        write(*, '("Pre-spin-loop for k-point",i4,": [X] Read projectors (",f10.2," secs)")') &
               ikGlobal, t2-t1
 
       

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -29,10 +29,8 @@ program transitionMatrixElements
   if(ionode) call cpu_time(t0)
 
 
-  if(ionode) &
-    write(*, '("Pre-k-loop: [ ] Read inputs  [ ] Read full PW grid ")') &
-          ikGlobal
-    call cpu_time(t1)
+  if(ionode) write(*, '("Pre-k-loop: [ ] Read inputs  [ ] Read full PW grid ")')
+  call cpu_time(t1)
 
 
   call readInput(maxGIndexGlobal, nKPoints, nGVecsGlobal, realLattVec, recipLattVec)

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -2370,8 +2370,7 @@ contains
           fNameBase = trim(VfisOutput)//'ofKpt'
           fNameSK = trim(fNameBase)//'.'//trim(ispC)//'.'//trim(ikC)
 
-          call execute_command_line('cat '//trim(fNameSK)//' >> '//trim(fNameBase))
-          call execute_command_line('rm '//trim(fNameSK))
+          call execute_command_line('cat '//trim(fNameSK)//' >> '//trim(fNameBase)//'&& rm '//trim(fNameSK))
 
         enddo
 

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -23,6 +23,8 @@ module declarations
     !! Error returned by MPI
   integer :: iGkStart_poolPC, iGkEnd_poolPC, iGkStart_poolSD, iGkEnd_poolSD
     !! Start and end G+k vector for process in pool
+  integer :: iGStart_pool, iGEnd_pool
+    !! Start and end G-vector for process in pool
   integer :: ikStart_pool, ikEnd_pool
     !! Start and end k-points in pool
   integer :: indexInPool
@@ -59,13 +61,15 @@ module declarations
     !! For timing different processes
 
 
-  integer, allocatable :: gKVecMillerIndicesGlobalPC(:,:), gkVecMillerIndicesGlobalSD(:,:)
-    !! Integer coefficients for G+k vectors
   integer :: maxGIndexGlobal
     !! Maximum G-vector index among all \(G+k\)
     !! and processors for PC and SD
+  integer, allocatable :: mill_local(:,:)
+    !! Local Miller indices
   integer :: nGVecsGlobal
     !! Global number of G-vectors
+  integer :: nGVecsLocal
+    !! Local number of G-vectors
   integer :: nGkVecsLocalPC, nGkVecsLocalSD
     !! Local number of G+k vectors on this processor
   integer :: nKPoints
@@ -1304,58 +1308,58 @@ contains
   end subroutine checkIfCalculated
 
 !----------------------------------------------------------------------------
-  subroutine readGrid(crystalType, ikGlobal, npws, gKVecMillerIndicesGlobal)
-
+  subroutine getFullPWGrid(iGStart_pool, iGEnd_pool, nGVecsLocal, nGVecsGlobal, mill_local)
+    !! Read full PW grid from mgrid file
+    
     implicit none
 
     ! Input variables:
-    integer, intent(in) :: ikGlobal
-      !! Current k point
-    integer, intent(in) :: npws
-      !! Number of G+k vectors less than
-      !! the cutoff at this k-point
-
-    character(len=2), intent(in) :: crystalType
-      !! Crystal type (PC or SD)
+    integer, intent(in) :: iGStart_pool, iGEnd_pool
+      !! Start and end G-vectors for each process in pool
+    integer, intent(in) :: nGVecsLocal
+      !! Local number of G-vectors
+    integer, intent(in) :: nGVecsGlobal
+      !! Global number of G-vectors
 
     ! Output variables:
-    integer, intent(out) :: gKVecMillerIndicesGlobal(3,npws)
-      !! Miller indices for G+k vectors for this k-point
-
+    integer, intent(out) :: mill_local(3,nGVecsLocal)
+      !! Integer coefficients for G-vectors
+    
     ! Local variables:
+    integer :: gVecMillerIndicesGlobal(3,nGVecsGlobal)
+      !! Integer coefficients for G-vectors on all processors
     integer :: iDum
-      !! Ignore index
+      !! Ignore dummy integer
     integer :: ig
       !! Loop index
-
-    character(len=300) :: ikC
-      !! Character index
-
-
-    call int2str(ikGlobal, ikC)
     
-    if(crystalType == 'PC') then
-      open(72, file=trim(exportDirPC)//"/grid."//trim(ikC))
-    else
-      open(72, file=trim(exportDirSD)//"/grid."//trim(ikC))
+
+    if(ionode) then
+
+      open(72, file=trim(exportDirSD)//"/mgrid")
+        !! Read full G-vector grid from defect folder.
+        !! This assumes that the grids are the same.
+    
+      read(72, * )
+      read(72, * )
+    
+      do ig = 1, nGVecsGlobal
+
+        read(72, '(4i10)') iDum, gVecMillerIndicesGlobal(1:3,ig)
+
+      enddo
+    
+      close(72)
+
     endif
-    
-    read(72, * )
-    read(72, * )
-      ! Ignore the header
-    
-    do ig = 1, npws
 
-      read(72, '(4i10)') iDum, gKVecMillerIndicesGlobal(:,ig)
-        !! Read the global PW indices that satisfy G+k < cutoff
+    call MPI_BCAST(gVecMillerIndicesGlobal, size(gVecMillerIndicesGlobal), MPI_INTEGER, root, worldComm, ierr)
 
-    enddo
+    mill_local(:,:) = gVecMillerIndicesGlobal(:,iGStart_pool:iGEnd_pool)
     
-    close(72)
-
     return
-
-  end subroutine readGrid
+    
+  end subroutine getFullPWGrid
 
 !----------------------------------------------------------------------------
   subroutine readProjectors(crystalType, iGkStart_pool, ikGlobal, nGkVecsLocal, nProjs, npws, betaLocalPWs)
@@ -1905,7 +1909,7 @@ contains
   end subroutine pawCorrectionWfc
 
 !----------------------------------------------------------------------------
-  subroutine pawCorrectionK(crystalType, nAtoms, iType, nGkVecsLocal, numOfTypes, mill_local, atomPositions, atoms, atomsSD, pawK)
+  subroutine pawCorrectionK(crystalType, nAtoms, iType, numOfTypes, atomPositions, atoms, atomsSD, pawK)
     
     implicit none
 
@@ -1914,12 +1918,8 @@ contains
       !! Number of atoms
     integer, intent(in) :: iType(nAtoms)
       !! Atom type index
-    integer, intent(in) :: nGkVecsLocal
-      !! Local number of G+k vectors on this processor
     integer, intent(in) :: numOfTypes
       !! Number of different atom types
-    integer, intent(in) :: mill_local(3,nGkVecsLocal)
-      !! Miller indices for local G+k vectors
 
     real(kind=dp), intent(in) :: atomPositions(3,nAtoms)
       !! Atom positions in Cartesian coordinates
@@ -1935,7 +1935,7 @@ contains
 
 
     ! Output variables:
-    complex(kind=dp) :: pawK(iBandFinit:iBandFfinal, iBandIinit:iBandIfinal, nGkVecsLocal)
+    complex(kind=dp), intent(out) :: pawK(iBandFinit:iBandFfinal,iBandIinit:iBandIfinal,nGVecsLocal)
 
     ! Local variables:
     real(kind=dp) :: gCart(3)
@@ -1951,10 +1951,10 @@ contains
     
     
     call cpu_time(t1)
-    
+
     pawK(:,:,:) = cmplx(0.0_dp, 0.0_dp, kind = dp)
     
-    do ig = 1, nGkVecsLocal
+    do ig = 1, nGVecsLocal
       
       do ix = 1, 3
         gCart(ix) = sum(mill_local(:,ig)*recipLattVec(ix,:))
@@ -2726,6 +2726,7 @@ contains
     deallocate(xkPC)
     deallocate(posIonPC)
     deallocate(TYPNIPC)
+    deallocate(mill_local)
 
     do iType = 1, numOfTypesPC
       deallocate(atomsPC(iType)%r)


### PR DESCRIPTION
Numbers looked pretty good in the past, but Guanzhi pointed out that the overlaps were inaccurate. I went back and tracked down all of the issues that were affecting the results and got them to match the original VASP Export results (current version of Export and original version of TME). I also added the full PW grid back to the PAW k correction in TME, which I had wrongly switched to the reduced G+k grid.