### PR TITLE
Move energy tabulation

### DIFF
--- a/EnergyTabulator/README.md
+++ b/EnergyTabulator/README.md
@@ -1,0 +1,36 @@
+# Energy Tabulator
+
+There are 4 different energy differences that need to be tabulated:
+* Delta function: total energy difference between individually-relaxed charge states, plus additional carrier energy above WZP reference-carrier energy
+* Zeroth-order matrix element: same as delta function but using total energy difference between charge states in the relaxed initial positions
+* First-order matrix element: eigenvalue difference between initial and final state
+* Plotting: eigenvalue difference between initial state and CBM (for electrons) or VBM (for holes)
+
+Instead of calculating these energies in all of the different programs in different ways, this program tabulates all of the required energies so that they can easily be read by other programs. Following the format of the other programs, this code will output an energy table file `energyTable.isp.ik` for each spin (`isp`) and k-point (`ik`). 
+
+The inputs should look like
+```f90
+&inputParams
+  ! Systems used for total energy differences
+  exportDirInitInit = 'path-to-relaxed-initial-charge-state-export'
+  exportDirFinalInit = 'path-to-final-charge-state-initial-positions-export'
+  exportDirFinalFinal = 'path-to-relaxed-final-charge-state-export'
+  
+  ! Parameters for change in energy
+  eCorrect = real						  ! size of energy correction in eV; default 0.0
+  refBand = integer						! band location of WZP reference carrier
+  CBMorVBMBand = integer      ! band for CBM (for electrons) or VBM (for holes)
+  
+  ! Band range for overlaps
+  iBandIinit = integer						! lowest initial-state band
+  iBandIfinal = integer						! highest initial-state band
+  iBandFinit = integer						! lowest final-state band
+  iBandFfinal = integer						! highest final-state band
+  
+  ! Output info
+  outputDir = 'path-to-store-energy-tables' 			! default './'
+/
+```
+_Note: Do not alter the `&inputParams` or `/` lines at the beginning and end of the file. They represent a namelist and fortran will not recognize the group of variables without this specific format_
+
+The code extracts the total energies from the three different systems and the eigenvalues from the initial relaxed system. It is best to use HSE calclations to get the energies, even if you can't do HSE for all of the matrix elements. If you can't use HSE for the energy differeences and/or need to include some additional energy correction in the total energy differences, that can be done through `eCorrect`.

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -1,0 +1,78 @@
+program energyTabulatorMain
+
+  use energyTabulatorMod
+  
+  implicit none
+
+  integer :: isp, ikLocal
+    !! Loop indices
+
+  real(kind=dp) :: t0, t2
+    !! Timers
+
+
+  call cpu_time(t0)
+
+  call mpiInitialization()
+
+  call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
+        exportDirFinalFinal, outputDir)
+    !! * Set default values for input variables and start timers
+
+  if(ionode) then
+    
+    read(5, inputParams, iostat=ierr)
+      !! * Read input variables
+    
+    if(ierr /= 0) call exitError('energy tabulator main', 'reading inputParams namelist', abs(ierr))
+      !! * Exit calculation if there's an error
+
+  call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
+        exportDirFinalFinal, outputDir)
+
+  endif
+
+  call MPI_BCAST(iBandIinit, 1, MPI_INTEGER, root, worldComm, ierr)
+  call MPI_BCAST(iBandIfinal, 1, MPI_INTEGER, root, worldComm, ierr)
+  call MPI_BCAST(iBandFinit, 1, MPI_INTEGER, root, worldComm, ierr)
+  call MPI_BCAST(iBandFfinal, 1, MPI_INTEGER, root, worldComm, ierr)
+  call MPI_BCAST(CBMorVBMBand, 1, MPI_INTEGER, root, worldComm, ierr)
+  call MPI_BCAST(refBand, 1, MPI_INTEGER, root, worldComm, ierr)
+
+  call MPI_BCAST(eCorrect, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+
+  call MPI_BCAST(exportDirInitInit, len(exportDirInitInit), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(exportDirFinalInit, len(exportDirFinalInit), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(exportDirFinalFinal, len(exportDirFinalFinal), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(outputDir, len(outputDir), MPI_CHARACTER, root, worldComm, ierr)
+
+
+  call getnSpinsAndnKPoints(exportDirInitInit, nKPoints, nSpins)
+    !! Assumes that all systems have the same number of spins and k-points
+
+  call distributeItemsInSubgroups(myid, nKPoints, nProcs, nProcs, nProcs, ikStart, ikEnd, nkPerProc)
+    !! * Distribute k-points in pools
+
+
+  call getTotalEnergies(exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, eTotInitInit, eTotFinalInit, eTotFinalFinal)
+    !! Get total energies from exports of all different structures
+
+
+  do isp = 1, nSpins
+    do ikLocal = 1, nkPerProc
+
+      call writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrect, &
+          eTotInitInit, eTotFinalInit, eTotFinalFinal, outputDir)
+
+    enddo
+  enddo
+
+
+  call MPI_Barrier(worldComm, ierr)
+ 
+  call cpu_time(t2)
+  if(ionode) write(*,'("************ Energy tabulator complete! (",f10.2," secs) ************")') t2-t0
+
+  call MPI_FINALIZE(ierr)
+
+end program energyTabulatorMain

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -1,0 +1,557 @@
+module energyTabulatorMod
+  
+  use constants, only: dp, eVToHartree
+  use miscUtilities, only: int2str
+  use errorsAndMPI
+  use mpi
+
+  implicit none
+
+  ! Global variables not passed as arguments:
+  integer :: ikStart, ikEnd
+    !! Start and end k-points for each process
+  integer :: nkPerProc
+    !! Number of k-points on each process
+
+
+  ! Variables that should be passed as arguments
+  integer :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+    !! Energy band bounds for initial and final state
+  integer :: CBMorVBMBand
+    !! Band of CBM (electron capture) or VBM (hole capture)
+  integer :: nKPoints
+    !! Number of k-points
+  integer :: nSpins
+    !! Number of spin channels
+  integer :: refBand
+    !! Band of WZP reference carrier
+
+  real(kind=dp) :: eCorrect
+    !! Total-energy correction, if any
+  real(kind=dp) :: eTotInitInit
+    !! Total energy of the relaxed initial charge
+    !! state (initial positions)
+  real(kind=dp) :: eTotFinalInit
+    !! Total energy of the unrelaxed final charge
+    !! state (initial positions)
+  real(kind=dp) :: eTotFinalFinal
+    !! Total energy of the relaxed final charge
+    !! state (final positions)
+
+  character(len=300) :: exportDirInitInit
+    !! Path to export for initial charge state
+    !! in the initial positions
+  character(len=300) :: exportDirFinalInit
+    !! Path to export for final charge state
+    !! in the initial positions
+  character(len=300) :: exportDirFinalFinal
+    !! Path to export for final charge state
+    !! in the final positions
+  character(len=300) :: outputDir
+    !! Path to store energy tables
+
+  namelist /inputParams/ exportDirFinalFinal, exportDirFinalInit, exportDirInitInit, outputDir, &
+                         eCorrect, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, refBand, CBMorVBMBand
+
+
+  contains
+
+!----------------------------------------------------------------------------
+  subroutine initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
+        exportDirFinalFinal, outputDir)
+    !! Set the default values for input variables and start timer
+    !!
+    !! <h2>Walkthrough</h2>
+    !!
+    
+    implicit none
+
+    ! Input variables:
+    !integer, intent(in) :: nProcs
+      ! Number of processes
+
+
+    ! Output variables:
+    integer, intent(out) :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+      !! Energy band bounds for initial and final state
+    integer, intent(out) :: CBMorVBMBand
+      !! Band of CBM (electron capture) or VBM (hole capture)
+    integer, intent(out) :: refBand
+      !! Band of WZP reference carrier
+
+    real(kind=dp), intent(out) :: eCorrect
+      !! Total-energy correction, if any
+
+    character(len=300), intent(out) :: exportDirInitInit
+      !! Path to export for initial charge state
+      !! in the initial positions
+    character(len=300), intent(out) :: exportDirFinalInit
+      !! Path to export for final charge state
+      !! in the initial positions
+    character(len=300), intent(out) :: exportDirFinalFinal
+      !! Path to export for final charge state
+      !! in the final positions
+    character(len=300), intent(out) :: outputDir
+      !! Path to store energy tables
+
+
+    ! Local variables:
+    character(len=8) :: cdate
+      !! String for date
+    character(len=10) :: ctime
+      !! String for time
+
+    iBandIinit  = -1
+    iBandIfinal = -1
+    iBandFinit  = -1
+    iBandFfinal = -1
+    refBand = -1
+    CBMorVBMBand = -1
+
+    eCorrect = 0.0_dp
+
+    exportDirInitInit = ''
+    exportDirFinalInit = ''
+    exportDirFinalFinal = ''
+    outputDir = './'
+
+    call date_and_time(cdate, ctime)
+
+    if(ionode) then
+
+      write(*, '(/5X,"Energy tabulator starts on ",A9," at ",A9)') &
+             cdate, ctime
+
+      write(*, '(/5X,"Parallel version (MPI), running on ",I5," processors")') nProcs
+
+
+    endif
+
+  end subroutine initialize
+
+!----------------------------------------------------------------------------
+  subroutine checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
+        exportDirFinalFinal, outputDir)
+
+    implicit none
+
+    ! Input variables:
+    integer, intent(in) :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+      !! Energy band bounds for initial and final state
+    integer, intent(in) :: CBMorVBMBand
+      !! Band of CBM (electron capture) or VBM (hole capture)
+    integer, intent(in) :: refBand
+      !! Band of WZP reference carrier
+
+    real(kind=dp), intent(inout) :: eCorrect
+      !! Total-energy correction, if any
+
+    character(len=300), intent(in) :: exportDirInitInit
+      !! Path to export for initial charge state
+      !! in the initial positions
+    character(len=300), intent(in) :: exportDirFinalInit
+      !! Path to export for final charge state
+      !! in the initial positions
+    character(len=300), intent(in) :: exportDirFinalFinal
+      !! Path to export for final charge state
+      !! in the final positions
+    character(len=300), intent(in) :: outputDir
+      !! Path to store energy tables
+
+    ! Local variables:
+    logical :: abortExecution
+      !! Whether or not to abort the execution
+
+
+    abortExecution = checkIntInitialization('iBandIinit', iBandIinit, 1, int(1e9))
+    abortExecution = checkIntInitialization('iBandIfinal', iBandIfinal, iBandIinit, int(1e9)) .or. abortExecution
+    abortExecution = checkIntInitialization('iBandFinit', iBandFinit, 1, int(1e9)) .or. abortExecution
+    abortExecution = checkIntInitialization('iBandFfinal', iBandFfinal, iBandFinit, int(1e9)) .or. abortExecution 
+    abortExecution = checkIntInitialization('refBand', refBand, 1, int(1e9)) .or. abortExecution
+    abortExecution = checkIntInitialization('CBMorVBMBand', CBMorVBMBand, 1, int(1e9)) .or. abortExecution
+
+    write(*,'("eCorrect = ", f8.4, " (eV)")') eCorrect
+
+    eCorrect = eCorrect*eVToHartree
+
+    abortExecution = checkDirInitialization('exportDirInitInit', exportDirInitInit, 'input') .or. abortExecution
+    abortExecution = checkDirInitialization('exportDirFinalInit', exportDirFinalInit, 'input') .or. abortExecution
+    abortExecution = checkDirInitialization('exportDirFinalFinal', exportDirFinalFinal, 'input') .or. abortExecution
+
+    call system('mkdir -p '//trim(outputDir))
+
+
+    if(abortExecution) then
+      write(*, '(" Program stops!")')
+      stop
+    endif
+    
+    return
+
+  end subroutine checkInitialization
+
+!----------------------------------------------------------------------------
+  subroutine getnSpinsAndnKPoints(exportDirInitInit, nKPoints, nSpins)
+
+    use miscUtilities, only: ignoreNextNLinesFromFile
+    
+    implicit none
+
+    ! Input variables:
+    character(len=300), intent(in) :: exportDirInitInit
+      !! Path to export for initial charge state
+      !! in the initial positions
+     
+    ! Output variables:
+    integer, intent(out) :: nKPoints
+      !! Number of k-points
+    integer, intent(out) :: nSpins
+      !! Number of spin channels
+    
+    
+    if(ionode) then
+    
+      open(50, file=trim(exportDirInitInit)//'/input', status = 'old')
+    
+      read(50,*) 
+      read(50,*) 
+      read(50,*) 
+      read(50, '(i10)') nSpins
+      read(50,*) 
+      read(50, '(i10)') nKPoints
+
+    endif
+
+    call MPI_BCAST(nSpins, 1, MPI_INTEGER, root, worldComm, ierr)
+    call MPI_BCAST(nKPoints, 1, MPI_INTEGER, root, worldComm, ierr)
+   
+    return
+
+  end subroutine getnSpinsAndnKPoints
+
+!----------------------------------------------------------------------------
+  subroutine getTotalEnergies(exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, eTotInitInit, eTotFinalInit, eTotFinalFinal)
+
+    use miscUtilities, only: getFirstLineWithKeyword
+
+    implicit none
+
+    ! Input variables:
+    character(len=300), intent(in) :: exportDirInitInit
+      !! Path to export for initial charge state
+      !! in the initial positions
+    character(len=300), intent(in) :: exportDirFinalInit
+      !! Path to export for final charge state
+      !! in the initial positions
+    character(len=300), intent(in) :: exportDirFinalFinal
+      !! Path to export for final charge state
+      !! in the final positions
+
+    ! Output variables:
+    real(kind=dp), intent(out) :: eTotInitInit
+      !! Total energy of the relaxed initial charge
+      !! state (initial positions)
+    real(kind=dp), intent(out) :: eTotFinalInit
+      !! Total energy of the unrelaxed final charge
+      !! state (initial positions)
+    real(kind=dp), intent(out) :: eTotFinalFinal
+      !! Total energy of the relaxed final charge
+      !! state (final positions)
+
+    ! Local variables:
+    character(len=300) :: line
+      !! Line from file
+
+
+    if(ionode) then
+      open(30,file=trim(exportDirFinalFinal)//'/input')
+      line = getFirstLineWithKeyword(30, 'Total Energy')
+      read(30,*) eTotFinalFinal
+      close(30)
+        !! Get the total energy of the relaxed final charge state
+        !! (final positions)
+
+      open(30,file=trim(exportDirFinalInit)//'/input')
+      line = getFirstLineWithKeyword(30, 'Total Energy')
+      read(30,*) eTotFinalInit
+      close(30)
+        !! Get the total energy of the unrelaxed final charge state
+        !! (initial positions)
+
+      open(30,file=trim(exportDirInitInit)//'/input')
+      line = getFirstLineWithKeyword(30, 'Total Energy')
+      read(30,*) eTotInitInit
+      close(30)
+        !! Get the total energy of the unrelaxed final charge state
+        !! (initial positions)
+
+    endif
+
+    call MPI_BCAST(eTotFinalFinal, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+    call MPI_BCAST(eTotFinalInit, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+    call MPI_BCAST(eTotInitInit, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+
+    return
+
+  end subroutine getTotalEnergies
+
+!----------------------------------------------------------------------------
+  subroutine writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrect, eTotInitInit, &
+        eTotFinalInit, eTotFinalFinal, outputDir)
+  
+    implicit none
+    
+    ! Input variables:
+    integer, intent(in) :: CBMorVBMBand
+      !! Band of CBM (electron capture) or VBM (hole capture)
+    integer, intent(in) :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+      !! Energy band bounds for initial and final state
+    integer, intent(in) :: ikLocal
+      !! Current local k-point
+    integer, intent(in) :: isp
+      !! Current spin channel
+    integer, intent(in) :: refBand
+      !! Band of WZP reference carrier
+
+    real(kind=dp), intent(in) :: eCorrect
+      !! Total-energy correction, if any
+    real(kind=dp), intent(in) :: eTotInitInit
+      !! Total energy of the relaxed initial charge
+      !! state (initial positions)
+    real(kind=dp), intent(in) :: eTotFinalInit
+      !! Total energy of the unrelaxed final charge
+      !! state (initial positions)
+    real(kind=dp), intent(in) :: eTotFinalFinal
+      !! Total energy of the relaxed final charge
+      !! state (final positions)
+
+    character(len=300), intent(in) :: outputDir
+      !! Path to store energy tables
+
+    ! Local variables:
+    integer :: ibi, ibf
+      !! Loop indices
+    integer :: ikGlobal
+      !! Current global k-point
+    integer :: totalNumberOfElements
+      !! Total number of overlaps to output
+
+    real(kind=dp) :: dE
+      !! Energy difference to be output
+    real(kind=dp) :: dEDelta
+      !! Energy to be used in delta function
+    real(kind=dp) :: dEFirst
+      !! Energy to be used in first-order matrix element
+    real(kind=dp) :: dEPlot
+      !! Energy to be used for plotting
+    real(kind=dp) :: dETotElecOnly
+      !! Total energy difference between charge states
+      !! with no change in atomic positions to get the
+      !! electronic-only energy to be used in the 
+      !! zeroth-order matrix element
+    real(kind=dp) :: dETotWRelax
+      !! Total energy difference between relaxed
+      !! charge states to be used in delta function
+    real(kind=dp) :: dEZeroth
+      !! Energy to be used in zeroth-order matrix element
+    real(kind=dp) :: eigCBMorVBM
+      !! Eigenvalue of either the CBM or VBM
+    real(kind=dp) :: eigvF(iBandFinit:iBandFfinal)
+      !! Final-state eigenvalues
+    real(kind=dp) :: eigvI(iBandIinit:iBandIfinal)
+      !! Initial-state eigenvalues
+    real(kind=dp) :: refEig
+      !! Eigenvalue of WZP reference carrier
+    real(kind=dp) :: t1, t2
+      !! Timers
+    
+    character(len = 300) :: text
+      !! Text for header
+
+
+    ikGlobal = ikLocal+ikStart-1
+    
+    call cpu_time(t1)
+    
+    write(*, '(" Writing energy table of k-point ", i2, " and spin ", i1, ".")') ikGlobal, isp
+    
+    open(17, file=trim(outputDir)//"/energyTable."//trim(int2str(isp))//"."//trim(int2str(ikGlobal)), status='unknown')
+    
+    text = "# Total number of <f|i> elements, Initial States (bandI, bandF), Final States (bandI, bandF)"
+    write(17,'(a, " Format : ''(5i10)''")') trim(text)
+    
+    totalNumberOfElements = (iBandIfinal - iBandIinit + 1)*(iBandFfinal - iBandFinit + 1)
+    write(17,'(5i10)') totalNumberOfElements, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+    
+
+    dETotWRelax = eTotFinalFinal - eTotInitInit + eCorrect 
+      !! Get the total energy difference between the two charge states, 
+      !! including the atomic relaxation energy (with a potential energy
+      !! correction defined by the user). This dE is used in the delta 
+      !! function.
+
+    write(17,'("# Total-energy difference (Hartree). Format: ''(ES24.15E3)''")') 
+    write(17,'("# With relaxation (for delta function)")')
+    write(17,'(ES24.15E3)') dETotWRelax
+
+
+    dETotElecOnly = eTotFinalInit - eTotInitInit + eCorrect
+      !! Get the total energy difference between the two charge states, 
+      !! not including atomic relaxation (with a potential energy correction
+      !! defined by the user). This dE represents the total electronic-only
+      !! energy difference between the two charge states and goes in the
+      !! zeroth-order matrix element.
+
+    write(17,'("# Electronic only without relaxation (for zeroth-order matrix element)")')
+    write(17,'(ES24.15E3)') dETotElecOnly
+    
+
+    text = "# Final Band, Initial Band, Delta Function, Zeroth-order, First-order, Plotting" 
+    write(17, '(a, " Format : ''(2i10,4ES24.15E3)''")') trim(text)
+
+
+    call readEigenvalues(CBMorVBMBand, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikGlobal, isp, refBand, exportDirInitInit, eigvF, eigvI, &
+          eigCBMorVBM, refEig)
+
+    do ibf = iBandFinit, iBandFfinal
+      do ibi = iBandIinit, iBandIfinal
+
+        dEDelta = dETotWRelax - abs(refEig - eigvI(ibi))
+          !! To get the total energy that needs to be conserved (what
+          !! goes into the delta function), add the total energy 
+          !! difference between the two relaxed charge states and the
+          !! additional eigenvalue energy difference between the initial
+          !! state and the WZP reference-carrier state. 
+          !!
+          !! In both hole and electron capture, the actual electron
+          !! energy decreases, so the negative absolute value of the
+          !! eigenvalue difference is used.
+
+        dEZeroth = dETotElecOnly - abs(refEig - eigvI(ibi))
+          !! The zeroth-order matrix element contains the electronic-only
+          !! energy difference. We get that from a total energy difference
+          !! between the two charge states in the initial positions. Like
+          !! in the energy for the delta function, the additional carrier
+          !! energy must also be included.
+
+        dEFirst = abs(eigvI(ibi) - eigvF(ibf))
+          !! First-order term contains only the unperturbed eigenvalue
+          !! difference. The perturbative expansion has 
+          !! \(\varepsilon_i - \varepsilon_f\), in terms of the actual 
+          !! electron. The absolute value is needed for the hole case.
+
+        dEPlot = abs(eigvI(ibi) - eigCBMorVBM)
+          !! Energy plotted should be positive carrier energy in reference
+          !! to the CBM (electrons) or VBM (holes)
+        
+        write(17, 1001) ibf, ibi, dEDelta, dEZeroth, dEFirst, dEPlot
+            
+      enddo
+    enddo
+
+    
+    close(17)
+    
+    call cpu_time(t2)
+    write(*, '(" Writing energy table of k-point ", i4, "and spin ", i1, " done in:                   ", f10.2, " secs.")') &
+      ikGlobal, isp, t2-t1
+    
+ 1001 format(2i7,4ES24.15E3)
+
+    return
+
+  end subroutine writeEnergyTable
+  
+!----------------------------------------------------------------------------
+  subroutine readEigenvalues(CBMorVBMBand, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikGlobal, isp, refBand, exportDirInitInit, eigvF, eigvI, &
+        eigCBMorVBM, refEig)
+
+    use miscUtilities, only: ignoreNextNLinesFromFile
+    
+    implicit none
+    
+    ! Input variables
+    integer, intent(in) :: CBMorVBMBand
+      !! Band of CBM (electron capture) or VBM (hole capture)
+    integer, intent(in) :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
+      !! Energy band bounds for initial and final state
+    integer, intent(in) :: ikGlobal
+      !! Current global k-point
+    integer, intent(in) :: isp
+      !! Current spin channel
+    integer, intent(in) :: refBand
+      !! Band of WZP reference carrier
+
+    character(len=300), intent(in) :: exportDirInitInit
+      !! Path to export for initial charge state
+      !! in the initial positions
+
+    ! Output variables:
+    real(kind=dp), intent(out) :: eigCBMorVBM
+      !! Eigenvalue of either the CBM or VBM
+    real(kind=dp), intent(out) :: eigvF(iBandFinit:iBandFfinal)
+      !! Final-state eigenvalues
+    real(kind=dp), intent(out) :: eigvI(iBandIinit:iBandIfinal)
+      !! Initial-state eigenvalues
+    real(kind=dp), intent(out) :: refEig
+      !! Eigenvalue of WZP reference carrier
+
+    ! Local variables:
+    integer :: ib
+      !! Loop index
+
+    character(len=300) :: fName
+      !! File name
+
+    
+    fName = trim(exportDirInitInit)//"/eigenvalues."//trim(int2str(isp))//"."//trim(int2str(ikGlobal))
+
+    open(72, file=fName)
+
+    call ignoreNextNLinesFromFile(72, 2 + (iBandIinit-1))
+      ! Ignore header and all bands before lowest initial-state band
+    
+    do ib = iBandIinit, iBandIfinal
+      read(72, '(ES24.15E3)') eigvI(ib)
+    enddo
+    
+    close(72)
+    
+
+    open(72, file=fName)
+
+    call ignoreNextNLinesFromFile(72, 2 + (iBandFinit-1))
+      ! Ignore header and all bands before lowest final-state band
+    
+    do ib = iBandFinit, iBandFfinal
+      read(72, '(ES24.15E3)') eigvF(ib)
+    enddo
+    
+    close(72)
+
+
+    open(72, file=fName)
+
+    call ignoreNextNLinesFromFile(72, 2 + (refBand-1))
+      ! Ignore header and all bands before reference band
+    
+    read(72, '(ES24.15E3)') refEig
+    
+    close(72)
+
+
+    open(72, file=fName)
+
+    call ignoreNextNLinesFromFile(72, 2 + (CBMorVBMBand-1))
+      ! Ignore header and all bands before either CBM or VBM
+    
+    read(72, '(ES24.15E3)') eigCBMorVBM
+    
+    close(72)
+
+    
+    return
+    
+  end subroutine readEigenvalues
+
+end module energyTabulatorMod

--- a/EnergyTabulator/src/Makefile
+++ b/EnergyTabulator/src/Makefile
@@ -1,0 +1,36 @@
+
+-include ../../make.sys
+
+# location of needed modules
+MODFLAGS= -I$(CommonModules_srcPath) -I.
+
+ENERGYTAB_OBJS = EnergyTabulator_module.o EnergyTabulator_main.o
+COMMONMODS = $(CommonModules_srcPath)/commonmodules.a
+
+all : EnergyTabulator.x 
+	
+EnergyTabulator.x : mods $(COMMONMODS) $(ENERGYTAB_OBJS)
+	$(mpif90) $(MODFLAGS) -o EnergyTabulator.x $(ENERGYTAB_OBJS) $(COMMONMODS)
+	- ( cd $(Home_Path)/bin ; ln -fs $(EnergyTabulator_srcPath)/$@ . )
+
+	@echo "" ; \
+	echo "" ; \
+	echo "Program 'EnergyTabulator' compiled successfully !" ; \
+	echo "" ; \
+	echo "" ; 
+
+mods :
+	cd $(CommonModules_srcPath) ; \
+	make
+
+%.o : %.f90
+	$(mpif90) $(MODFLAGS) -O3 -c -assume byterecl -fpp $<
+
+clean :
+
+	@echo "" ; \
+	echo "Cleaning folder 'EnergyTabulator' ... " ; \
+	/bin/rm -f *.x *.o *.mod .DS_Store ; \
+	echo "Cleaning folder 'EnergyTabulator' done !" ; \
+	echo "" ;
+

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ mpif90 = ftn
 ########################################################################
 
 
-all : initialize QE-5.0.2_dependent QE-5.3.0_dependent QE-6.3_dependent Export_VASP TME LSF0 Mj LSF1 Sigma
+all : initialize QE-5.0.2_dependent QE-5.3.0_dependent QE-6.3_dependent Export_VASP EnergyTabulator TME LSF0 Mj LSF1 Sigma
 
 help :
 
@@ -50,6 +50,7 @@ help :
 	@echo "    make Export_QE-5.3.0          to built the Quantum Espresso 5.3.0 dependent Export module."
 	@echo "    make Export_QE-6.3            to built the Quantum Espresso 6.3 dependent Export module."
 	@echo "    make Export_VASP              to built the VASP Export code"
+	@echo "    make EnergyTabulator          to built the energy tabulation code."
 	@echo "    make TME                      to built the Transition Matrix Elements (TME) module."
 	@echo "    make PhononPP                 to built the phonon post-processing module."
 	@echo "    make Mj                       to built the Mj module."
@@ -65,6 +66,7 @@ help :
 	@echo "    make cleanExport_QE-6.3            to clean the Quantum Espresso 6.3 dependent Export module."
 	@echo "    make cleanPhononPP                 to clean the phonon post-processing module."
 	@echo "    make cleanMj                       to clean the Mj module."
+	@echo "    make cleanEnergyTabulator          to clean the energy tabulation code."
 	@echo "    make cleanTME                      to clean the Transition Matrix Elements (TME) module."
 	@echo "    make cleanLSF                      to clean the Line Shape Function (LSF) module."
 	@echo "    make cleanSigma                    to clean the Cross Section (Sigma) module."
@@ -74,16 +76,17 @@ help :
 
 Export_QE-5.0.2_srcPath = Export/QE/5.0.2/src
 Export_QE-5.3.0_srcPath = Export/QE/5.3/src
-Export_QE-6.3_srcPath = Export/QE/6.3/src
-Export_VASP_srcPath = Export/VASP/src
-TME_srcPath    = TME/src
-Mj_srcPath     = Mj/src
-LSF_srcPath    = LSF/src
-LSF0_srcPath   = $(LSF_srcPath)/zerothOrder
-LSF1_srcPath   = $(LSF_srcPath)/linearTerms
-Sigma_srcPath  = Sigma/src
-CommonModules_srcPath  = CommonModules
-PhononPP_srcPath = PhononPP/src
+Export_QE-6.3_srcPath   = Export/QE/6.3/src
+Export_VASP_srcPath     = Export/VASP/src
+EnergyTabulator_srcPath = EnergyTabulator/src
+TME_srcPath             = TME/src
+Mj_srcPath              = Mj/src
+LSF_srcPath             = LSF/src
+LSF0_srcPath            = $(LSF_srcPath)/zerothOrder
+LSF1_srcPath            = $(LSF_srcPath)/linearTerms
+Sigma_srcPath           = Sigma/src
+CommonModules_srcPath   = CommonModules
+PhononPP_srcPath        = PhononPP/src
 
 bin = './bin'
 
@@ -101,12 +104,12 @@ QE-5.3.0_dependent : initialize Export_QE-5.3.0
 
 QE-6.3_dependent : initialize Export_QE-6.3
 
-base : TME LSF0 LSF1 Mj PhononPP Sigma
+base : EnergyTabulator TME LSF0 LSF1 Mj PhononPP Sigma
 
 initialize :
 
 	@echo "" > make.sys ; \
-	echo "Home_Path      = " $(PWD) >> make.sys ; \
+	echo "Home_Path               = " $(PWD) >> make.sys ; \
 	echo "QE-5.0.2_Path           = " $(QE-5.0.2_Path) >> make.sys ; \
 	echo "QE-5.3.0_Path           = " $(QE-5.3.0_Path) >> make.sys ; \
 	echo "QE-6.3_Path             = " $(QE-6.3_Path) >> make.sys ; \
@@ -114,6 +117,7 @@ initialize :
 	echo "Export_QE-5.3.0_srcPath = " $(PWD)/$(Export_QE-5.3.0_srcPath) >> make.sys ; \
 	echo "Export_QE-6.3_srcPath   = " $(PWD)/$(Export_QE-6.3_srcPath) >> make.sys ; \
 	echo "Export_VASP_srcPath     = " $(PWD)/$(Export_VASP_srcPath) >> make.sys ; \
+	echo "EnergyTabulator_srcPath = " $(PWD)/$(EnergyTabulator_srcPath) >> make.sys ; \
 	echo "TME_srcPath             = " $(PWD)/$(TME_srcPath) >> make.sys ; \
 	echo "PhononPP_srcPath        = " $(PWD)/$(PhononPP_srcPath) >> make.sys ; \
 	echo "Mj_srcPath              = " $(PWD)/$(Mj_srcPath) >> make.sys ; \
@@ -160,6 +164,11 @@ Export_VASP : initialize
 	@cd $(Export_VASP_srcPath) ; \
 		make all
 
+EnergyTabulator : initialize
+
+	@cd $(EnergyTabulator_srcPath) ; \
+        	make all
+
 TME : initialize
 
 	@cd $(TME_srcPath) ; \
@@ -193,19 +202,15 @@ Sigma : initialize
 	@cd $(Sigma_srcPath) ; \
         	make all
 
-clean : cleanExport_VASP clean_QE-5.0.2_dependent clean_QE-5.3.0_dependent clean_QE-6.3_dependent cleanTME cleanInitialization cleanPhononPP cleanMj cleanLSF0 cleanLSF1 cleanSigma
+clean : cleanExport_VASP cleanExport_QE-5.0.2 cleanExport_QE-5.3.0 cleanExport_QE-6.3 cleanBase
 
-clean_all_QE-5.0.2 : clean_QE-5.0.2_dependent cleanTME cleanInitialization cleanPhononPP cleanMj cleanLSF0 cleanLSF1 cleanSigma
+clean_all_QE-5.0.2 : cleanExport_QE-5.0.2 cleanBase
 
-clean_all_QE-5.3.0 : clean_QE-5.3.0_dependent cleanTME cleanInitialization cleanPhononPP cleanMj cleanLSF0 cleanLSF1 cleanSigma
+clean_all_QE-5.3.0 : cleanExport_QE-5.3.0 cleanBase
 
-clean_all_QE-6.3 : clean_QE-6.3_dependent cleanTME cleanInitialization cleanPhononPP cleanMj cleanLSF0 cleanLSF1 cleanSigma
+clean_all_QE-6.3 : cleanExport_QE-6.3 cleanBase
 
-clean_QE-5.0.2_dependent : cleanExport_QE-5.0.2
-
-clean_QE-5.3.0_dependent : cleanExport_QE-5.3.0
-
-clean_QE-6.3_dependent : cleanExport_QE-6.3
+cleanBase : cleanInitialization cleanEnergyTabulator cleanTME cleanPhononPP cleanMj cleanLSF0 cleanLSF1 cleanSigma
 
 cleanInitialization :
 
@@ -235,6 +240,12 @@ cleanExport_VASP :
 
 	@cd $(Export_VASP_srcPath) ; \
         	make clean
+
+cleanEnergyTabulator :
+
+	@cd $(EnergyTabulator_srcPath) ; \
+		make clean
+
 cleanTME :
 
 	@cd $(TME_srcPath) ; \

--- a/TME/README.md
+++ b/TME/README.md
@@ -5,27 +5,22 @@ The `TME` program outputs matrix elements for a range of initial and final band 
 The code also assumes that all atom types in the `PC` system are also in the `SD` system in the same order and that any atoms in the SD system not in the PC system are at the end.
 
 Output files are 
-* `allElecOverlap.isp.ik` -- for each band in range and a given spin and k-point: initial and final band, energy difference, all-electron overlaps, and matrix elements
+* `allElecOverlap.isp.ik` -- for each band in range and a given spin and k-point: initial and final band, all-electron overlaps, and matrix elements
 * `output` -- information about input variables
 * `VfisVsEofKpt`/`VfisVsE` -- optional k-binned matrix elements
 * stdout -- timing information and status updates
+
+The same TME code is used for both the zeroth-order and the first-order matrix elements. For both orders, the overlap part comes from from the TME code and the energy difference comes from the [`EnergyTabulator`](../EnergyTabulator) code.
 
 ## Zeroth-order
 
 The zeroth-order term has a single matrix element that is shown in the GaN paper to be $$M_{\text{e}}^{\text{BO}} = \langle \phi_f | \psi_i^0 \rangle (E_f - E_i),$$ where $E_f - E_i$ is the total electronic energy difference of the defect crystal before and after capture and $|\phi_f\rangle$ and $|\psi_i^0\rangle$ are the single-quasiparticle orbitals of the final defect state and the perfect-crystal initial state, respectively. 
 
-For capture, you must do two separate total-energy calculations for the different defect charge states because the system will relax. The position of the carrier to be captured in the excited-state total-energy calculation is the reference position. You must be clear on where your WZP reference carrier is for the energy difference to be correct. For example, if you consider the $0/-$ transition in $\text{Si}_{\text{V}}\text{H}_3$, your initial state should really have an electron in the conduction band and a hole in the valence band or a donor. However, when using a hole as the compensating charge rather than a donor, the wave functions will not be significantly changed by moving the delocalized electron from the conduction band to the valence band. However, the energy must be adjusted based on the different positions of your reference carrier. 
-
-The `TME` input file for the zeroth-order term should look like
+The `TME` input file for the zeroth-order should look like
 ```f90
 &TME_Input
   ! Which order of matrix element to calculate
   order = 0
-  
-  ! Parameters for change in energy
-  capturing = 'elec' or 'hole'					! what kind of carrier is being captured
-  eCorrect = real						! size of energy correction in eV; default 0.0
-  refBand = integer						! band location of reference carrier
   
   ! Systems used for overlaps
   exportDirSD = 'path-to-final-charge-state-initial-positions-export'
@@ -37,11 +32,6 @@ The `TME` input file for the zeroth-order term should look like
   iBandFinit = integer						! lowest final-state band
   iBandFfinal = integer						! highest final-state band
     ! Note: code logic only currently tested for single final band state (iBandFinit = iBandFfinal)
-  
-  
-  ! Systems used for total energy difference (only for order = 0)
-  exportDirInit = 'path-to-relaxed-initial-charge-state-export'
-  exportDirFinal = 'path-to-relaxed-final-charge-state-export'
   
   ! Output info
   elementsPath = 'path-to-store-overlap-files' 			! default './TMEs'
@@ -61,11 +51,6 @@ The `TME` input file for the first-order term should look like
 &TME_Input
   ! Which order of matrix element to calculate
   order = 1
-  
-  ! Parameters for change in energy
-  capturing = 'elec' or 'hole'		! what kind of carrier is being captured
-  eCorrect = real						      ! size of energy correction in eV; default 0.0
-  refBand = integer						    ! band location of reference carrier
   
   ! Systems used for overlaps
   exportDirSD = 'path-to-displaced-defect-export'

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -81,8 +81,6 @@ program transitionMatrixElements
   call cpu_time(t1)
     
 
-  if(indexInPool == 0) allocate(eigvI(iBandIinit:iBandIfinal), eigvF(iBandFinit:iBandFfinal))
-  
   allocate(Ufi(iBandFinit:iBandFfinal, iBandIinit:iBandIfinal, nKPerPool, nSpins))
   Ufi(:,:,:,:) = cmplx(0.0_dp, 0.0_dp, kind = dp)
   


### PR DESCRIPTION
The energies were being extracted in the TME code, but I realized that we have several programs that need different energies. Instead of having each one extract and calculate the correct energy difference, I moved the energy tabulation to a separate program so that the other codes can just read the correct value.