### PR TITLE
Update energy tabulator

### DIFF
--- a/EnergyTabulator/README.md
+++ b/EnergyTabulator/README.md
@@ -11,6 +11,9 @@ Instead of calculating these energies in all of the different programs in differ
 The inputs should look like
 ```f90
 &inputParams
+  ! System used for eigenvalues
+  exportDirEigs = 'path-to-system-export-for-eigenvalues'
+
   ! Systems used for total energy differences
   exportDirInitInit = 'path-to-relaxed-initial-charge-state-export'
   exportDirFinalInit = 'path-to-final-charge-state-initial-positions-export'
@@ -35,7 +38,7 @@ The inputs should look like
 ```
 _Note: Do not alter the `&inputParams` or `/` lines at the beginning and end of the file. They represent a namelist and fortran will not recognize the group of variables without this specific format_
 
-The code extracts the total energies from the three different systems and the eigenvalues from the initial relaxed system. It is best to use HSE calclations to get the energies, even if you can't do HSE for all of the matrix elements. If you can't use HSE for the energy differeences and/or need to include some additional energy correction in the total energy differences, that can be done through `eCorrect`.
+The code extracts the total energies from the three different systems and the eigenvalues from the specified eigenvalue system. It is best to use HSE calclations to get the energies, even if you can't do HSE for all of the matrix elements. If you can't use HSE for the energy differences and/or need to include some additional energy correction in the total energy differences, that can be done through `eCorrectTot`. The eigenvalues are best from the ground-state HSE as well, but if that cannot be used (e.g., if many k-points are used and that isn't feasible), PBE-level eigenvalues can be used. Within the conduction band/valence band, PBE eigenvalue differences are okay, but you may need to include corrections to the reference carrier (`eCorrectEigRef`) and final state (`eCorrectEigF`).
 
 The energies are calculated including potential energy corrections as
 ```f90

--- a/EnergyTabulator/README.md
+++ b/EnergyTabulator/README.md
@@ -6,7 +6,7 @@ There are 4 different energy differences that need to be tabulated:
 * First-order matrix element: eigenvalue difference between initial and final state
 * Plotting: eigenvalue difference between initial state and CBM (for electrons) or VBM (for holes)
 
-Instead of calculating these energies in all of the different programs in different ways, this program tabulates all of the required energies so that they can easily be read by other programs. Following the format of the other programs, this code will output an energy table file `energyTable.isp.ik` for each spin (`isp`) and k-point (`ik`). 
+Instead of calculating these energies in all of the different programs in different ways, this program tabulates all of the required energies so that they can easily be read by other programs. Following the format of the other programs, this code will output an energy table file `energyTable.isp.ik` for each spin (`isp`) and k-point (`ik`). The spins and k-points come from the system that is used for the eigenvalues. 
 
 The inputs should look like
 ```f90

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -16,7 +16,7 @@ program energyTabulatorMain
   call mpiInitialization()
 
   call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
-        exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
+        exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
     !! * Set default values for input variables and start timers
 
   if(ionode) then
@@ -28,7 +28,7 @@ program energyTabulatorMain
       !! * Exit calculation if there's an error
 
     call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
-          exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
+          exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
 
   endif
 
@@ -43,6 +43,7 @@ program energyTabulatorMain
   call MPI_BCAST(eCorrectEigF, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
   call MPI_BCAST(eCorrectEigRef, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
+  call MPI_BCAST(exportDirEigs, len(exportDirEigs), MPI_CHARACTER, root, worldComm, ierr)
   call MPI_BCAST(exportDirInitInit, len(exportDirInitInit), MPI_CHARACTER, root, worldComm, ierr)
   call MPI_BCAST(exportDirFinalInit, len(exportDirFinalInit), MPI_CHARACTER, root, worldComm, ierr)
   call MPI_BCAST(exportDirFinalFinal, len(exportDirFinalFinal), MPI_CHARACTER, root, worldComm, ierr)
@@ -64,7 +65,7 @@ program energyTabulatorMain
     do ikLocal = 1, nkPerProc
 
       call writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
-            eTotInitInit, eTotFinalInit, eTotFinalFinal, outputDir)
+            eTotInitInit, eTotFinalInit, eTotFinalFinal, exportDirEigs, outputDir)
 
     enddo
   enddo

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -50,7 +50,7 @@ program energyTabulatorMain
   call MPI_BCAST(outputDir, len(outputDir), MPI_CHARACTER, root, worldComm, ierr)
 
 
-  call getnSpinsAndnKPoints(exportDirInitInit, nKPoints, nSpins)
+  call getnSpinsAndnKPoints(exportDirEigs, nKPoints, nSpins)
     !! Assumes that all systems have the same number of spins and k-points
 
   call distributeItemsInSubgroups(myid, nKPoints, nProcs, nProcs, nProcs, ikStart, ikEnd, nkPerProc)
@@ -64,7 +64,7 @@ program energyTabulatorMain
   do isp = 1, nSpins
     do ikLocal = 1, nkPerProc
 
-      call writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
+      call writeEnergyTable(CBMorVBMBand, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikLocal, isp, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
             eTotInitInit, eTotFinalInit, eTotFinalFinal, exportDirEigs, outputDir)
 
     enddo

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -15,8 +15,8 @@ program energyTabulatorMain
 
   call mpiInitialization()
 
-  call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
-        exportDirFinalFinal, outputDir)
+  call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
+        exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
     !! * Set default values for input variables and start timers
 
   if(ionode) then
@@ -27,8 +27,8 @@ program energyTabulatorMain
     if(ierr /= 0) call exitError('energy tabulator main', 'reading inputParams namelist', abs(ierr))
       !! * Exit calculation if there's an error
 
-    call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrect, exportDirInitInit, exportDirFinalInit, &
-          exportDirFinalFinal, outputDir)
+    call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
+          exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, outputDir)
 
   endif
 
@@ -39,7 +39,9 @@ program energyTabulatorMain
   call MPI_BCAST(CBMorVBMBand, 1, MPI_INTEGER, root, worldComm, ierr)
   call MPI_BCAST(refBand, 1, MPI_INTEGER, root, worldComm, ierr)
 
-  call MPI_BCAST(eCorrect, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+  call MPI_BCAST(eCorrectTot, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+  call MPI_BCAST(eCorrectEigF, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+  call MPI_BCAST(eCorrectEigRef, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
   call MPI_BCAST(exportDirInitInit, len(exportDirInitInit), MPI_CHARACTER, root, worldComm, ierr)
   call MPI_BCAST(exportDirFinalInit, len(exportDirFinalInit), MPI_CHARACTER, root, worldComm, ierr)
@@ -61,8 +63,8 @@ program energyTabulatorMain
   do isp = 1, nSpins
     do ikLocal = 1, nkPerProc
 
-      call writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrect, &
-          eTotInitInit, eTotFinalInit, eTotFinalFinal, outputDir)
+      call writeEnergyTable(CBMorVBMBand, iBandIInit, iBandIFinal, iBandFInit, iBandFFinal, ikLocal, isp, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
+            eTotInitInit, eTotFinalInit, eTotFinalFinal, outputDir)
 
     enddo
   enddo

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -438,7 +438,7 @@ module energyTabulatorMod
     write(17,'(ES24.15E3)') dETotElecOnly
     
 
-    text = "# Final Band, Initial Band, Delta Function, Zeroth-order, First-order, Plotting" 
+    text = "# Final Band, Initial Band, Delta Function (Hartree), Zeroth-order (Hartree), First-order (Hartree), Plotting (eV)" 
     write(17, '(a, " Format : ''(2i10,4ES24.15E3)''")') trim(text)
 
 

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -218,16 +218,15 @@ module energyTabulatorMod
   end subroutine checkInitialization
 
 !----------------------------------------------------------------------------
-  subroutine getnSpinsAndnKPoints(exportDirInitInit, nKPoints, nSpins)
+  subroutine getnSpinsAndnKPoints(exportDirEigs, nKPoints, nSpins)
 
     use miscUtilities, only: ignoreNextNLinesFromFile
     
     implicit none
 
     ! Input variables:
-    character(len=300), intent(in) :: exportDirInitInit
-      !! Path to export for initial charge state
-      !! in the initial positions
+    character(len=300), intent(in) :: exportDirEigs
+      !! Path to export for system to get eigenvalues
      
     ! Output variables:
     integer, intent(out) :: nKPoints
@@ -238,7 +237,7 @@ module energyTabulatorMod
     
     if(ionode) then
     
-      open(50, file=trim(exportDirInitInit)//'/input', status = 'old')
+      open(50, file=trim(exportDirEigs)//'/input', status = 'old')
     
       read(50,*) 
       read(50,*) 


### PR DESCRIPTION
Currently have the eigenvalues coming from init, init, but Xiaoguang said that the ground-state eigenvalues are more accurate. Additionally, we now want to use the PBE eigenvalues and the HSE energy differences. This merge allows for different corrections for the different orders and allows to user to choose the path for the eigenvalues directly. The number of spins and k-points gets pulled from the system used for the eigenvalues.