### PR TITLE
Export energies only

### DIFF
--- a/CommonModules/errorsAndMPI.f90
+++ b/CommonModules/errorsAndMPI.f90
@@ -63,13 +63,17 @@ module errorsAndMPI
   contains
 
 !----------------------------------------------------------------------------
-  subroutine mpiInitialization()
+  subroutine mpiInitialization(programName)
     !! Generate MPI processes and communicators 
     !!
     !! <h2>Walkthrough</h2>
     !!
 
     implicit none
+
+    ! Input variables ::
+    character(*) :: programName
+      !! Program name to output with starting message
 
     ! Output variables:
     !integer, intent(out) :: myid
@@ -81,6 +85,12 @@ module errorsAndMPI
 
     !logical, intent(out) :: ionode
       ! If this node is the root node
+
+    ! Local variables:
+    character(len=8) :: cdate
+      !! String for date
+    character(len=10) :: ctime
+      !! String for time
 
 
     call MPI_Init(ierr)
@@ -98,6 +108,17 @@ module errorsAndMPI
 
     ionode = (myid == root)
       ! Set a boolean for if this is the root process
+
+
+    call date_and_time(cdate, ctime)
+
+    if(ionode) then
+
+      write(*, '(/5X,a, " starts on ",A9," at ",A9)') trim(programName), cdate, ctime
+
+      write(*, '(/5X,"Parallel version (MPI), running on ",I5," processors")') nProcs
+
+    endif
 
     return
   end subroutine mpiInitialization

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -13,7 +13,7 @@ program energyTabulatorMain
 
   call cpu_time(t0)
 
-  call mpiInitialization()
+  call mpiInitialization('EnergyTabulator')
 
   call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, CBMorVBMBand, refBand, eCorrectTot, eCorrectEigF, eCorrectEigRef, &
         energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal)

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -102,12 +102,6 @@ module energyTabulatorMod
       !! Path to export for final charge state
       !! in the final positions
 
-    ! Local variables:
-    character(len=8) :: cdate
-      !! String for date
-    character(len=10) :: ctime
-      !! String for time
-
 
     iBandIinit  = -1
     iBandIfinal = -1
@@ -125,18 +119,6 @@ module energyTabulatorMod
     exportDirInitInit = ''
     exportDirFinalInit = ''
     exportDirFinalFinal = ''
-
-    call date_and_time(cdate, ctime)
-
-    if(ionode) then
-
-      write(*, '(/5X,"Energy tabulator starts on ",A9," at ",A9)') &
-             cdate, ctime
-
-      write(*, '(/5X,"Parallel version (MPI), running on ",I5," processors")') nProcs
-
-
-    endif
 
   end subroutine initialize
 

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -29,7 +29,7 @@ program wfcExportVASPMain
 
   call cpu_time(t0)
 
-  call mpiInitialization()
+  call mpiInitialization('Export')
 
   call getCommandLineArguments()
     !! * Get the number of pools from the command line
@@ -38,34 +38,8 @@ program wfcExportVASPMain
     !! * Split up processors between pools and generate MPI
     !!   communicators for pools
 
-  call initialize(energiesOnly, gammaOnly, exportDir, VASPDir)
-    !! * Set default values for input variables, open output file,
-    !!   and start timers
-
-  if ( ionode ) then
-    
-    read(5, inputParams, iostat=ierr)
-      !! * Read input variables
-    
-    if(ierr /= 0) call exitError('export main', 'reading inputParams namelist', abs(ierr))
-      !! * Exit calculation if there's an error
-
-    call execute_command_line('mkdir -p '//trim(exportDir))
-      !! * Make the export directory
-    
-    mainOutputFile = trim(exportDir)//"/input"
-      !! * Set the name of the main output file for export
-    
-    write(iostd,*) "Opening file "//trim(mainOutputFile)
-    open(mainOutFileUnit, file=trim(mainOutputFile))
-      !! * Open main output file
-
-  endif
-
-  call MPI_BCAST(exportDir, len(exportDir), MPI_CHARACTER, root, worldComm, ierr)
-  call MPI_BCAST(VASPDir, len(VASPDir), MPI_CHARACTER, root, worldComm, ierr)
-  call MPI_BCAST(energiesOnly, 1, MPI_LOGICAL, root, worldComm, ierr)
-  call MPI_BCAST(gammaOnly, 1, MPI_LOGICAL, root, worldComm, ierr)
+  call readInputParams(energiesOnly, gammaOnly, exportDir, VASPDir)
+    !! * Initialize, read, check, and broadcast input parameters
 
   if(ionode) &
     write(*, '("[ ] WAVECAR  [ ] vasprun.xml  [ ] Set up grid  [ ] POTCAR")')

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -38,7 +38,7 @@ program wfcExportVASPMain
     !! * Split up processors between pools and generate MPI
     !!   communicators for pools
 
-  call initialize(gammaOnly, exportDir, VASPDir)
+  call initialize(energiesOnly, gammaOnly, exportDir, VASPDir)
     !! * Set default values for input variables, open output file,
     !!   and start timers
 
@@ -64,6 +64,7 @@ program wfcExportVASPMain
 
   call MPI_BCAST(exportDir, len(exportDir), MPI_CHARACTER, root, worldComm, ierr)
   call MPI_BCAST(VASPDir, len(VASPDir), MPI_CHARACTER, root, worldComm, ierr)
+  call MPI_BCAST(energiesOnly, 1, MPI_LOGICAL, root, worldComm, ierr)
   call MPI_BCAST(gammaOnly, 1, MPI_LOGICAL, root, worldComm, ierr)
 
   if(ionode) &

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -115,6 +115,8 @@ module wfcExportVASPMod
   integer :: nRecords
     !! Number of records in WAVECAR file
 
+  logical :: energiesOnly
+    !! If only energy-related files should be exported
   logical :: gammaOnly
     !! If the gamma only VASP code is used
   
@@ -160,13 +162,13 @@ module wfcExportVASPMod
 
   type (potcar), allocatable :: pot(:)
 
-  namelist /inputParams/ VASPDir, exportDir, gammaOnly
+  namelist /inputParams/ VASPDir, exportDir, gammaOnly, energiesOnly
 
 
   contains
 
 !----------------------------------------------------------------------------
-  subroutine initialize(gammaOnly, exportDir, VASPDir)
+  subroutine initialize(energiesOnly, gammaOnly, exportDir, VASPDir)
     !! Set the default values for input variables, open output files,
     !! and start timer
     !!
@@ -183,6 +185,8 @@ module wfcExportVASPMod
 
 
     ! Output variables:
+    logical, intent(out) :: energiesOnly
+      !! If only energy-related files should be exported
     logical, intent(out) :: gammaOnly
       !! If the gamma only VASP code is used
 
@@ -200,6 +204,7 @@ module wfcExportVASPMod
 
     VASPDir = './'
     exportDir = './Export'
+    energiesOnly = .false.
     gammaOnly = .false.
 
     call cpu_time(tStart)

--- a/Export/VASP/src/Makefile
+++ b/Export/VASP/src/Makefile
@@ -11,9 +11,7 @@ DEBUGFLAGS = -check -traceback -gen-interfaces
 
 all : Export_VASP.x 
 
-test : Export_VASP_test.x
-
-%.x : mods $(COMMONMODS) $(EXPORTOBJS)
+Export_VASP.x : mods $(COMMONMODS) $(EXPORTOBJS)
 	$(mpif90) $(MODFLAGS) -o $@	$(EXPORTOBJS) $(COMMONMODS)
 	- ( cd $(Home_Path)/bin ; ln -fs $(Export_VASP_srcPath)/$@ . )
 	

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -19,7 +19,7 @@ program LSFmain
 
   call cpu_time(timerStart)
 
-  call mpiInitialization()
+  call mpiInitialization('LSF')
 
   call getCommandLineArguments()
     !! * Get the number of pools from the command line

--- a/LSF/src/LSF_module.f90
+++ b/LSF/src/LSF_module.f90
@@ -215,12 +215,6 @@ contains
     character(len=300), intent(out) :: SjInput
       !! Path to Sj.out file
 
-    ! Local variables:
-    character(len=8) :: cdate
-      !! String for date
-    character(len=10) :: ctime
-      !! String for time
-
 
     iBandIinit  = -1
     iBandIfinal = -1
@@ -240,18 +234,6 @@ contains
     SjInput = ''
     outputDir = './'
     prefix = 'disp-'
-
-    call date_and_time(cdate, ctime)
-
-    if(ionode) then
-
-      write(*, '(/5X,"LSF starts on ",A9," at ",A9)') &
-             cdate, ctime
-
-      write(*, '(/5X,"Parallel version (MPI), running on ",I5," processors")') nProcs
-
-
-    endif
 
     return 
 

--- a/PhononPP/src/Shifter_main.f90
+++ b/PhononPP/src/Shifter_main.f90
@@ -11,7 +11,7 @@ program shifterMain
 
   call cpu_time(t0)
 
-  call mpiInitialization()
+  call mpiInitialization('Shifter')
 
   call initialize(shift, dqFName, phononFName, poscarFName, prefix)
     !! * Set default values for input variables and start timers

--- a/PhononPP/src/Shifter_module.f90
+++ b/PhononPP/src/Shifter_module.f90
@@ -62,11 +62,6 @@ module shifterMod
     
     implicit none
 
-    ! Input variables:
-    !integer, intent(in) :: nProcs
-      ! Number of processes
-
-
     ! Output variables:
     real(kind=dp), intent(out) :: shift
       !! Magnitude of shift along phonon eigenvectors
@@ -81,29 +76,13 @@ module shifterMod
       !! Prefix for shifted POSCARs
 
 
-    ! Local variables:
-    character(len=8) :: cdate
-      !! String for date
-    character(len=10) :: ctime
-      !! String for time
-
     dqFName = 'dq.txt'
     poscarFName = 'POSCAR'
     phononFName = 'mesh.yaml'
     prefix = 'ph_POSCAR'
     shift = 0.01_dp
 
-    call date_and_time(cdate, ctime)
-
-    if(ionode) then
-
-      write(*, '(/5X,"Phonon post-processing: POSCAR shifter starts on ",A9," at ",A9)') &
-             cdate, ctime
-
-      write(*, '(/5X,"Parallel version (MPI), running on ",I5," processors")') nProcs
-
-
-    endif
+    return
 
   end subroutine initialize
 

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -21,7 +21,7 @@ program TMEmain
     !! Character index
 
   
-  call mpiInitialization()
+  call mpiInitialization('TME')
     !! Initialize MPI
 
   call getCommandLineArguments()


### PR DESCRIPTION
We only need the energies from some HSE calculations or when we are extracting the group velocities, so add the option to export energies only. This is especially needed for gamma-only calculations where the `vasp_gam` version makes some assumptions that affect the way the grid is calculated in a way that is not accounted for in the Export program currently.