### PR TITLE
Fix memory issues to run on Perlmutter

### DIFF
--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -113,7 +113,7 @@ program wfcExportVASPMain
 
 
     call reconstructFFTGrid(nGVecsLocal, gIndexLocalToGlobal, nKPoints, nPWs1kGlobal, kPosition, gVecInCart, recipLattVec, &
-        wfcVecCut, gKIndexOrigOrderLocal, gKSort, maxGIndexGlobal, maxGkVecsLocal, maxNumPWsGlobal, maxNumPWsPool, &
+        wfcVecCut, gKSort, igkSort2OrigLocal, maxGIndexGlobal, maxGkVecsLocal, maxNumPWsGlobal, maxNumPWsPool, &
         nGkLessECutGlobal, nGkVecsLocal)
       !! * Determine which G-vectors result in \(G+k\)
       !!   below the energy cutoff for each k-point and
@@ -148,11 +148,11 @@ program wfcExportVASPMain
   if(.not. energiesOnly) then
 
     call projAndWav(maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
-        nSpins, gKIndexOrigOrderLocal, gKSort, gVecMillerIndicesGlobal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, &
+        nSpins, gKSort, gVecMillerIndicesGlobal, igkSort2OrigLocal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, &
         recipLattVec, exportDir, VASPDir, gammaOnly, pot)
 
 
-    deallocate(gKIndexOrigOrderLocal, gKSort, nGkVecsLocal, iGkStart_pool, iGkEnd_pool)
+    deallocate(igkSort2OrigLocal, gKSort, nGkVecsLocal, iGkStart_pool, iGkEnd_pool)
   endif
 
   deallocate(nPWs1kGlobal)

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -113,8 +113,7 @@ program wfcExportVASPMain
 
 
     call reconstructFFTGrid(nGVecsLocal, gIndexLocalToGlobal, nKPoints, nPWs1kGlobal, kPosition, gVecInCart, recipLattVec, &
-        wfcVecCut, gKSort, igkSort2OrigLocal, maxGIndexGlobal, maxGkVecsLocal, maxNumPWsGlobal, maxNumPWsPool, &
-        nGkLessECutGlobal, nGkVecsLocal)
+        wfcVecCut, igkSort2OrigLocal, maxGIndexGlobal, maxGkVecsLocal, nGkLessECutGlobal, nGkVecsLocal)
       !! * Determine which G-vectors result in \(G+k\)
       !!   below the energy cutoff for each k-point and
       !!   sort the indices based on \(|G+k|^2\)
@@ -147,12 +146,11 @@ program wfcExportVASPMain
 
   if(.not. energiesOnly) then
 
-    call projAndWav(maxGkVecsLocal, maxNumPWsGlobal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, &
-        nSpins, gKSort, gVecMillerIndicesGlobal, igkSort2OrigLocal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, &
-        recipLattVec, exportDir, VASPDir, gammaOnly, pot)
+    call projAndWav(maxGkVecsLocal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, nSpins, gVecMillerIndicesGlobal, &
+        igkSort2OrigLocal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, recipLattVec, exportDir, VASPDir, gammaOnly, pot)
 
 
-    deallocate(igkSort2OrigLocal, gKSort, nGkVecsLocal, iGkStart_pool, iGkEnd_pool)
+    deallocate(igkSort2OrigLocal, nGkVecsLocal, iGkStart_pool, iGkEnd_pool)
   endif
 
   deallocate(nPWs1kGlobal)

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -2355,8 +2355,8 @@ module wfcExportVASPMod
       !> because they are not dependent on spin. Calculate in one band 
       !> group and broadcast to the others because doesn't depend on 
       !> band index.
-      if(myBgrpId == 0) call calculatePhase(nAtoms, nGkVecsLocal_ik, nGVecsGlobal, nKPoints, gVecMillerIndicesGlobal, &
-            igkSort2OrigLocal_ik, atomPositionsDir, phaseExp)
+      if(myBgrpId == 0) call calculatePhase(nAtoms, nGkVecsLocal_ik, nGVecsGlobal, gVecMillerIndicesGlobal, igkSort2OrigLocal_ik, &
+            atomPositionsDir, phaseExp)
 
       call MPI_BCAST(phaseExp, size(phaseExp), MPI_DOUBLE_COMPLEX, 0, interBgrpComm, ierr)
 
@@ -2443,7 +2443,7 @@ module wfcExportVASPMod
   end subroutine projAndWav
 
 !----------------------------------------------------------------------------
-  subroutine calculatePhase(nAtoms, nGkVecsLocal_ik, nGVecsGlobal, nKPoints, gVecMillerIndicesGlobal, igkSort2OrigLocal_ik, &
+  subroutine calculatePhase(nAtoms, nGkVecsLocal_ik, nGVecsGlobal, gVecMillerIndicesGlobal, igkSort2OrigLocal_ik, &
                 atomPositionsDir, phaseExp)
 
     implicit none
@@ -2458,8 +2458,6 @@ module wfcExportVASPMod
       !! Global number of G-vectors
     !integer, intent(in) :: nkPerPool
       ! Number of k-points in each pool
-    integer, intent(in) :: nKPoints
-      !! Total number of k-points
     integer, intent(in) :: gVecMillerIndicesGlobal(3,nGVecsGlobal)
       !! Integer coefficients for G-vectors on all processors
     integer, intent(in) :: igkSort2OrigLocal_ik(nGkVecsLocal_ik)

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -86,7 +86,7 @@ module wfcExportVASPMod
     !! Global number of \(G+k\) vectors with magnitude
     !! less than `wfcVecCut` for each k-point
   integer, allocatable :: nGkVecsLocal(:)
-    !! Local number of G-vectors on this processor
+    !! Local number of G+k-vectors on this processor
   integer :: nGVecsGlobal
     !! Global number of G-vectors
   integer :: nGVecsLocal
@@ -1232,7 +1232,7 @@ module wfcExportVASPMod
       !! Global number of \(G+k\) vectors with magnitude
       !! less than `wfcVecCut` for each k-point
     integer, allocatable, intent(out) :: nGkVecsLocal(:)
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
 
 
     ! Local variables:
@@ -1771,7 +1771,7 @@ module wfcExportVASPMod
     !integer, intent(in) :: nkPerPool
       ! Number of k-points in each pool
     integer, intent(in) :: nGkLessECutGlobal(nKPoints)
-      !! Global number of G-vectors
+      !! Global number of G+k-vectors
     !integer, intent(in) :: nProcPerPool
       ! Number of processes per pool
 
@@ -1790,7 +1790,7 @@ module wfcExportVASPMod
       !! Max number of G+k vectors across all k-points
       !! in this pool
     integer, allocatable, intent(out) :: nGkVecsLocal(:)
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
 
 
     ! Local variables:
@@ -2242,7 +2242,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nBands
       !! Total number of bands
     integer, intent(in) :: nGkVecsLocal(nkPerPool)
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
     integer, intent(in) :: nGVecsGlobal
       !! Global number of G-vectors
     !integer, intent(in) :: nkPerPool
@@ -2352,10 +2352,9 @@ module wfcExportVASPMod
       call cpu_time(t1)
 
       !> Calculate the projectors and phase only once for each k-point
-      !> because they are not dependent on spin. Write them out as if 
-      !> they were dependent on spin because that is how TME currently
-      !> expects it. Calculate in one band group and broadcast to the 
-      !> others because doesn't depend on band index.
+      !> because they are not dependent on spin. Calculate in one band 
+      !> group and broadcast to the others because doesn't depend on 
+      !> band index.
       if(myBgrpId == 0) call calculatePhase(nAtoms, nGkVecsLocal_ik, nGVecsGlobal, nKPoints, gVecMillerIndicesGlobal, &
             igkSort2OrigLocal_ik, atomPositionsDir, phaseExp)
 
@@ -2453,7 +2452,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nAtoms
       !! Number of atoms
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     integer, intent(in) :: nGVecsGlobal
       !! Global number of G-vectors
@@ -2516,7 +2515,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nAtomTypes
       !! Number of types of atoms
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     !integer, intent(in) :: nkPerPool
       ! Number of k-points in each pool
@@ -2681,7 +2680,7 @@ module wfcExportVASPMod
 
     ! Input variables:
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     !integer, intent(in) :: nkPerPool
       ! Number of k-points in each pool
@@ -2853,7 +2852,7 @@ module wfcExportVASPMod
 
     ! Input variables:
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     integer, intent(in) :: YDimL
       !! L dimension of spherical harmonics;
@@ -2941,7 +2940,7 @@ module wfcExportVASPMod
     integer, intent(in) :: ip
       !! Channel index
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
 
     real(kind=dp), intent(in) :: gkMod(nGkVecsLocal_ik)
@@ -3075,7 +3074,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nAtomsEachType(nAtomTypes)
       !! Number of atoms of each type
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     integer, intent(in) :: nKPoints
       !! Total number of k-points
@@ -3281,7 +3280,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nBands
       !! Total number of bands
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     integer, intent(in) :: nKPoints
       !! Total number of k-points
@@ -3434,7 +3433,7 @@ module wfcExportVASPMod
     integer, intent(in) :: nAtomsEachType(nAtomTypes)
       !! Number of atoms of each type
     integer, intent(in) :: nGkVecsLocal_ik
-      !! Local number of G-vectors on this processor
+      !! Local number of G+k-vectors on this processor
       !! for a given k-point
     integer, intent(in) :: nProj
       !! Number of projectors across all atom types

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ QE-5.3.0_dependent : initialize Export_QE-5.3.0
 
 QE-6.3_dependent : initialize Export_QE-6.3
 
-base : EnergyTabulator GVel TME LSF Mj PhononPP Sigma
+base : EnergyTabulator TME LSF PhononPP Sigma
 
 initialize :
 

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -55,7 +55,7 @@ program TMEmain
 
   allocate(mill_local(3,nGVecsLocal))
 
-  call getFullPWGrid(iGStart_pool, iGEnd_pool, nGVecsLocal, nGVecsGlobal, mill_local)
+  call getFullPWGrid(iGStart_pool, nGVecsLocal, nGVecsGlobal, mill_local)
 
   
   call cpu_time(t2)

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -17,9 +17,6 @@ program TMEmain
     !! that are normally done for the first channel
     !! only
 
-  character(len=300) :: ikC
-    !! Character index
-
   
   call mpiInitialization('TME')
     !! Initialize MPI
@@ -128,7 +125,7 @@ program TMEmain
 
       allocate(betaPC(nGkVecsLocalPC,nProjsPC))
 
-      call readProjectors('PC', iGkStart_poolPC, ikGlobal, nGkVecsLocalPC, nProjsPC, npwsPC(ikGlobal), betaPC)
+      call readProjectors('PC', iGkStart_poolPC, ikGlobal, nGkVecsLocalPC, nProjsPC, betaPC)
 
 
       call distributeItemsInSubgroups(indexInPool, npwsSD(ikGlobal), nProcPerPool, nProcPerPool, nProcPerPool, iGkStart_poolSD, &
@@ -136,7 +133,7 @@ program TMEmain
 
       allocate(betaSD(nGkVecsLocalSD,nProjsSD))
 
-      call readProjectors('SD', iGkStart_poolSD, ikGlobal, nGkVecsLocalSD, nProjsSD, npwsSD(ikGlobal), betaSD)
+      call readProjectors('SD', iGkStart_poolSD, ikGlobal, nGkVecsLocalSD, nProjsSD, betaSD)
 
       call cpu_time(t2)
       if(ionode) write(*, '("  Pre-spin-loop: [X] Read projectors (",f10.2," secs)")') t2-t1
@@ -207,11 +204,11 @@ program TMEmain
           !> Calculate cross projections
 
           if(isp == 1 .or. nSpinsSD == 2 .or. spin1Read) &
-            call calculateCrossProjection(iBandFinit, iBandFfinal, ikGlobal, nGkVecsLocalPC, nGkVecsLocalSD, nProjsPC, betaPC, wfcSD, cProjBetaPCPsiSD)
+            call calculateCrossProjection(iBandFinit, iBandFfinal, nGkVecsLocalPC, nGkVecsLocalSD, nProjsPC, betaPC, wfcSD, cProjBetaPCPsiSD)
 
 
           if(isp == 1 .or. nSpinsPC == 2 .or. spin1Read) &
-            call calculateCrossProjection(iBandIinit, iBandIfinal, ikGlobal, nGkVecsLocalSD, nGkVecsLocalPC, nProjsSD, betaSD, wfcPC, cProjBetaSDPhiPC)
+            call calculateCrossProjection(iBandIinit, iBandIfinal, nGkVecsLocalSD, nGkVecsLocalPC, nProjsSD, betaSD, wfcPC, cProjBetaSDPhiPC)
         
 
           call cpu_time(t2)


### PR DESCRIPTION
The code was not previously able to run on Perlmutter because the memory requirements caused seg faults. 

### Projectors
I updated the way the projectors were written so that all of the projectors for a single plane wave were written on a single record. This change reduced the memory and broadcasts needed in both the Export code and the TME code. 

### Wave function coefficients
I also updated the way the wave function coefficients were written so that the root in each band group outputs the coefficients as soon as they are read, rather than storing all of the coefficients for each band, broadcasting, then writing. This significantly reduced the memory needs.

### Full PW Grid
I also slightly changed the reading of the PW grid in the TME code so that the full PW grid was only stored on a single process. 

### General cleaning
I also removed the `gKSort` variable because the sorting doesn't make a difference in the results as long as the projectors and wave functions are in the same order. With all of the changes, I removed unused variables and changed some variable names for clarity.