### PR TITLE
Add option to select spin channel

### DIFF
--- a/CommonModules/base.f90
+++ b/CommonModules/base.f90
@@ -4,11 +4,18 @@ module base
 
   integer :: iBandIinit, iBandIfinal, iBandFinit, iBandFfinal
     !! Energy band bounds for initial and final state
+  integer :: ispSelect
+    !! Selection of a single spin channel if input
+    !! by the user
   integer :: nKPoints
     !! Total number of k-points
   integer :: nSpins
     !! Max number of spins for both systems
   integer :: order
     !! Order of matrix element (0 or 1)
+
+  logical :: loopSpins
+    !! Whether to loop over available spin channels;
+    !! otherwise, use selected spin channel
 
 end module base

--- a/EnergyTabulator/README.md
+++ b/EnergyTabulator/README.md
@@ -6,7 +6,7 @@ There are 4 different energy differences that need to be tabulated:
 * First-order matrix element: eigenvalue difference between initial and final state
 * Plotting: same as zeroth-order but positive and in eV
 
-Instead of calculating these energies in all of the different programs in different ways, this program tabulates all of the required energies so that they can easily be read by other programs. Following the format of the other programs, this code will output an energy table file `energyTable.isp.ik` for each spin (`isp`) and k-point (`ik`). The spins and k-points come from the system that is used for the eigenvalues. 
+Instead of calculating these energies in all of the different programs in different ways, this program tabulates all of the required energies so that they can easily be read by other programs. Following the format of the other programs, this code will output an energy table file `energyTable.isp.ik` for each spin (`isp`) (or the single selected spin) and k-point (`ik`). The spins and k-points come from the system that is used for the eigenvalues. 
 
 The inputs should look like
 ```f90
@@ -18,6 +18,9 @@ The inputs should look like
   exportDirInitInit = 'path-to-relaxed-initial-charge-state-export'
   exportDirFinalInit = 'path-to-final-charge-state-initial-positions-export'
   exportDirFinalFinal = 'path-to-relaxed-final-charge-state-export'
+
+  ! Spin channel selection; default unused
+  ispSelect = integer   
 
   ! Physical problem details
   captured = .true. or .false.      ! If the carrier is captured

--- a/Export/VASP/README.md
+++ b/Export/VASP/README.md
@@ -11,6 +11,7 @@ The results must then be post-processed to be used as input to the other program
 The input file should look like
 ```f90
 &inputParams
+  ispSelect = integer                                   ! selection of a single spin channel; default unused
   VASPDir = 'path-to-VASP-output'                       ! default './'
   exportDir = 'path-to-put-exported-files'              ! default './Export'
   gammaOnly = logical                                   ! default .false.

--- a/Export/VASP/README.md
+++ b/Export/VASP/README.md
@@ -27,7 +27,6 @@ The output files are
 * `eigenvalues.isp.ik` -- eigenvalues for each band for given spin channel and k-point
 * `groupedEigenvalues.isp.ik` -- grouped eigenvalues for each base k-point and spin channel if `groupForGroupVelocity = .true.`
 * `grid.ik` -- Miller indices for G-vectors such that $G+k < $ cutoff
-* `groundState` -- highest occupied band for each spin channel and k-point
 * `input` -- main output file with cell, k-point, pseudopotential information, and total energy
 * `mgrid` -- full G-vector grid in Miller indices
 * `projections.isp.ik` -- $\langle \beta | \psi \rangle$ for given spin channel and k-point

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -48,7 +48,7 @@ program wfcExportVASPMain
 
 
   call readWAVECAR(ispSelect, loopSpins, VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
-      kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, nSpinsCalc, reclenWav, eigenE)
+      kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, reclenWav, eigenE)
     !! * Read cell and wavefunction data from the WAVECAR file
 
 

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -48,7 +48,7 @@ program wfcExportVASPMain
 
 
   call readWAVECAR(ispSelect, loopSpins, VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
-      kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, reclenWav, eigenE)
+      kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, nSpinsCalc, reclenWav, eigenE)
     !! * Read cell and wavefunction data from the WAVECAR file
 
 

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -239,7 +239,7 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call writeEigenvalues(nBands, nKPoints, nSpins, bandOccupation, eFermi, eTot, eigenE)
+  call writeEigenvalues(ispSelect, nBands, nKPoints, nSpins, bandOccupation, eFermi, eTot, eigenE, loopSpins)
     !! * Write Fermi energy and eigenvalues and occupations for each band
 
   if(groupForGroupVelocity) then

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -148,8 +148,9 @@ program wfcExportVASPMain
 
   if(.not. energiesOnly) then
 
-    call projAndWav(maxGkVecsLocal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, nSpins, gVecMillerIndicesGlobalSort, &
-        igkSort2OrigLocal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, recipLattVec, exportDir, VASPDir, gammaOnly, pot)
+    call  projAndWav(ispSelect, maxGkVecsLocal, nAtoms, nAtomTypes, nBands, nGkVecsLocal, nGVecsGlobal, nKPoints, nSpins, &
+        gVecMillerIndicesGlobalSort, igkSort2OrigLocal, nPWs1kGlobal, reclenWav, atomPositionsDir, kPosition, omega, recipLattVec, &
+        exportDir, VASPDir, gammaOnly, loopSpins, pot)
 
 
     deallocate(igkSort2OrigLocal, nGkVecsLocal, iGkStart_pool, iGkEnd_pool, gVecMillerIndicesGlobalSort)

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -180,11 +180,15 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call writeGridInfo(nGVecsGlobal, gVecMillerIndicesGlobalOrig, maxGIndexGlobal, exportDir)
+  if(ionode) call writeGridInfo(nGVecsGlobal, gVecMillerIndicesGlobalOrig, maxGIndexGlobal, exportDir)
     !! * Write out grid boundaries and miller indices
     !!   for just \(G+k\) combinations below cutoff energy
     !!   in one file and all miller indices in another 
     !!   file
+    !!
+    !!  Make sure only ionode calls this subroutine because
+    !!  `gVecMillerIndicesGlobalOrig` is not allocated on the
+    !!  other processes
 
   if(.not. energiesOnly .and. ionode) deallocate(gVecMillerIndicesGlobalOrig)
 

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -164,9 +164,8 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call writeKInfo(nBands, nKPoints, nGkLessECutGlobal, nSpins, bandOccupation, kWeight, kPosition)
-    !! * Calculate ground state and write out k-point 
-    !!   information to `input` file
+  call writeKInfo(nKPoints, nGkLessECutGlobal, nSpins, kWeight, kPosition)
+    !! * Write out k-point information to `input` file
 
   deallocate(kPosition)
   deallocate(kWeight)

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -38,7 +38,8 @@ program wfcExportVASPMain
     !! * Split up processors between pools and generate MPI
     !!   communicators for pools
 
-  call readInputParams(ispSelect, nDispkPerCoord, patternArr, energiesOnly, gammaOnly, groupForGroupVelocity, exportDir, pattern, VASPDir)
+  call readInputParams(ispSelect, nDispkPerCoord, patternArr, energiesOnly, gammaOnly, groupForGroupVelocity, loopSpins, &
+      exportDir, pattern, VASPDir)
     !! * Initialize, read, check, and broadcast input parameters
 
   if(ionode) &

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -38,7 +38,7 @@ program wfcExportVASPMain
     !! * Split up processors between pools and generate MPI
     !!   communicators for pools
 
-  call readInputParams(nDispkPerCoord, patternArr, energiesOnly, gammaOnly, groupForGroupVelocity, exportDir, pattern, VASPDir)
+  call readInputParams(ispSelect, nDispkPerCoord, patternArr, energiesOnly, gammaOnly, groupForGroupVelocity, exportDir, pattern, VASPDir)
     !! * Initialize, read, check, and broadcast input parameters
 
   if(ionode) &

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -47,7 +47,7 @@ program wfcExportVASPMain
   call cpu_time(t1)
 
 
-  call readWAVECAR(VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
+  call readWAVECAR(ispSelect, loopSpins, VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
       kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, reclenWav, eigenE)
     !! * Read cell and wavefunction data from the WAVECAR file
 

--- a/Export/VASP/src/Export_VASP_main.f90
+++ b/Export/VASP/src/Export_VASP_main.f90
@@ -243,7 +243,7 @@ program wfcExportVASPMain
     !! * Write Fermi energy and eigenvalues and occupations for each band
 
   if(groupForGroupVelocity) then
-    call writeGroupedEigenvalues(nBands, nDispkPerCoord, nKPoints, nSpins, bandOccupation, patternArr, eigenE, pattern)
+    call writeGroupedEigenvalues(ispSelect, nBands, nDispkPerCoord, nKPoints, nSpins, bandOccupation, patternArr, eigenE, loopSpins, pattern)
     deallocate(patternArr)
   endif
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -1,6 +1,6 @@
 module wfcExportVASPMod
   
-  use constants, only: dp, angToBohr, eVToRy, ryToHartree, pi, twopi
+  use constants, only: dp, angToBohr, eVToRy, RyToHartree, eVToHartree, pi, twopi
   use base, only: nKPoints, nSpins
   use errorsAndMPI
   use cell
@@ -823,7 +823,7 @@ module wfcExportVASPMod
 
       close(wavecarUnit)
 
-      eigenE(:,:,:) = eigenE(:,:,:)*eVToRy
+      eigenE(:,:,:) = eigenE(:,:,:)*eVToHartree
 
     endif
 
@@ -3679,21 +3679,23 @@ module wfcExportVASPMod
       flush(mainOutFileUnit)
     
       do isp = 1, nSpins
-        do ik = 1, nKPoints
+        if(loopSpins .or. isp == ispSelect) then
+          do ik = 1, nKPoints
 
-          open(72, file=trim(exportDir)//"/eigenvalues."//trim(int2str(isp))//"."//trim(int2str(ik)))
+            open(72, file=trim(exportDir)//"/eigenvalues."//trim(int2str(isp))//"."//trim(int2str(ik)))
       
-          write(72, '("# Spin, k-point index: ",2i10, " Format: ''(a23, 2i10)''")') isp, ik
-          write(72, '("# Eigenvalues (Hartree), band occupation number. Format: ''(2ES24.15E3)''")')
+            write(72, '("# Spin, k-point index: ",2i10, " Format: ''(a23, 2i10)''")') isp, ik
+            write(72, '("# Eigenvalues (Hartree), band occupation number. Format: ''(2ES24.15E3)''")')
       
-          do ib = 1, nBands
+            do ib = 1, nBands
+  
+              write(72, '(i10, 2ES24.15E3)') ib, real(eigenE(isp,ik,ib)), bandOccupation(isp,ib,ik)
 
-            write(72, '(i10, 2ES24.15E3)') ib, real(eigenE(isp,ik,ib))*ryToHartree, bandOccupation(isp,ib,ik)
-
+            enddo
+      
+            close(72)
           enddo
-      
-          close(72)
-        enddo
+        endif
       enddo
 
     endif

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -561,6 +561,7 @@ module wfcExportVASPMod
 
     call MPI_BCAST(reclenWav, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(nSpins, 1, MPI_INTEGER, root, worldComm, ierr)
+    call MPI_BCAST(nSpinsCalc, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(nKPoints, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(nBands, 1, MPI_INTEGER, root, worldComm, ierr)
     call MPI_BCAST(wfcVecCut, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -365,7 +365,7 @@ module wfcExportVASPMod
   end subroutine checkInitialization
 
 !----------------------------------------------------------------------------
-  subroutine readWAVECAR(VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
+  subroutine readWAVECAR(ispSelect, loopSpins, VASPDir, realLattVec, recipLattVec, bandOccupation, omega, wfcVecCut, &
         kPosition, fftGridSize, nBands, nKPoints, nPWs1kGlobal, nSpins, reclenWav, eigenE)
     !! Read cell and wavefunction data from the WAVECAR file
     !!
@@ -375,9 +375,16 @@ module wfcExportVASPMod
     implicit none
 
     ! Input variables:
+    integer, intent(in) :: ispSelect
+      !! Selection of a single spin channel if input
+      !! by the user
+
+    logical, intent(in) :: loopSpins
+      !! Whether to loop over available spin channels;
+      !! otherwise, use selected spin channel
+
     character(len=256), intent(in) :: VASPDir
       !! Directory with VASP files
-
     
     ! Output variables:
     real(kind=dp), intent(out) :: realLattVec(3,3)
@@ -451,6 +458,14 @@ module wfcExportVASPMod
       nSpins = nint(nspin_real)
       prec = nint(prec_real)
         ! Convert input variables to integers
+
+
+      if(.not. loopSpins .and. checkIntInitialization('ispSelect', ispSelect, 1, nSpins)) &
+        call exitError('readWAVECAR', 'selected spin larger than number of spin channels available', 1)
+        ! Not looping spins (i.e., a single spin channel was selected),
+        ! make sure that the selected spin channel is not larger than
+        ! the number of spin channels available in the system
+
 
       if(prec .eq. 45210) call exitError('readWAVECAR', 'WAVECAR_double requires complex*16', 1)
 

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -3357,7 +3357,7 @@ module wfcExportVASPMod
   end subroutine getAndWriteProjections
 
 !----------------------------------------------------------------------------
-  subroutine writeKInfo(nBands, nKPoints, nGkLessECutGlobal, nSpins, bandOccupation, kWeight, kPosition)
+  subroutine writeKInfo(nKPoints, nGkLessECutGlobal, nSpins, kWeight, kPosition)
     !! Calculate the highest occupied band for each k-point
     !! and write out k-point information
     !!
@@ -3367,8 +3367,6 @@ module wfcExportVASPMod
     implicit none
 
     ! Input variables:
-    integer, intent(in) :: nBands
-      !! Total number of bands
     integer, intent(in) :: nKPoints
       !! Total number of k-points
     integer, intent(in) :: nGkLessECutGlobal(nKPoints)
@@ -3377,50 +3375,17 @@ module wfcExportVASPMod
     integer, intent(in) :: nSpins
       !! Number of spins
 
-    real(kind=dp), intent(in) :: bandOccupation(nSpins, nBands, nKPoints)
-      !! Occupation of band
     real(kind=dp), intent(in) :: kWeight(nKPoints)
       !! K-point weights
     real(kind=dp), intent(in) :: kPosition(3,nKPoints)
       !! Position of k-points in reciprocal space
 
-
-    ! Output variables:
-
-
     ! Local variables:
-    integer :: groundState(nSpins,nKPoints)
-      !! Holds the highest occupied band
-      !! for each k-point and spin
-    integer :: ik, isp
-      !! Loop indices
+    integer :: ik
+      !! Loop index
 
 
     if(ionode) then
-
-      call getGroundState(nBands, nKPoints, nSpins, bandOccupation, groundState)
-        !! * For each k-point, find the index of the 
-        !!   highest occupied band
-        !!
-        !! @note
-        !!  Although `groundState` is written out in `Export`,
-        !!  it is not currently used by the `TME` program.
-        !! @endnote
-
-      open(72, file=trim(exportDir)//"/groundState")
-
-      write(72, '("# isp, ik, groundState(isp,ik). Format: ''(3i10)''")')
-
-      do isp = 1, nSpins
-        do ik = 1, nKPoints
-
-          write(72, '(3i10)') isp, ik, groundState(isp,ik)
-
-        enddo
-      enddo
-
-      close(72)
-          
 
       write(mainOutFileUnit, '("# Number of spins. Format: ''(i10)''")')
       write(mainOutFileUnit, '(i10)') nSpins
@@ -3450,60 +3415,6 @@ module wfcExportVASPMod
 
     return
   end subroutine writeKInfo
-
-!----------------------------------------------------------------------------
-  subroutine getGroundState(nBands, nKPoints, nSpins, bandOccupation, groundState)
-    !! * For each k-point, find the index of the 
-    !!   highest occupied band
-
-    implicit none
-
-    ! Input variables:
-    integer, intent(in) :: nBands
-      !! Total number of bands
-    integer, intent(in) :: nKPoints
-      !! Total number of k-points
-    integer, intent(in) :: nSpins
-      !! Number of spins
-
-    real(kind=dp), intent(in) :: bandOccupation(nSpins, nBands, nKPoints)
-      !! Occupation of band
-
-    
-    ! Output variables:
-    integer, intent(out) :: groundState(nSpins, nKPoints)
-      !! Holds the highest occupied band
-      !! for each k-point and spin
-
-
-    ! Local variables:
-    integer :: ik, ibnd, isp
-      !! Loop indices
-
-
-    groundState(:,:) = 0
-    do isp = 1, nSpins
-      do ik = 1, nKPoints
-
-        do ibnd = 1, nBands
-
-          if (bandOccupation(isp,ibnd,ik) < 0.5_dp) then
-            !! @todo Figure out if boundary for "occupied" should be 0.5 or less @endtodo
-          !if (et(ibnd,ik) > ef) then
-
-            groundState(isp,ik) = ibnd - 1
-            goto 10
-
-          endif
-        enddo
-
-10      continue
-
-      enddo
-    enddo
-
-    return
-  end subroutine getGroundState
 
 !----------------------------------------------------------------------------
   subroutine writeGridInfo(nGVecsGlobal, gVecMillerIndicesGlobalOrig, maxGIndexGlobal, exportDir)

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -1,7 +1,7 @@
 module wfcExportVASPMod
   
   use constants, only: dp, angToBohr, eVToRy, RyToHartree, eVToHartree, pi, twopi
-  use base, only: nKPoints, nSpins
+  use base, only: nKPoints, nSpins, ispSelect, loopSpins
   use errorsAndMPI
   use cell
   use mpi
@@ -76,9 +76,6 @@ module wfcExportVASPMod
     !! and for local PWs in the original order
   integer, allocatable :: iMill(:)
     !! Indices of miller indices after sorting
-  integer :: ispSelect
-    !! Selection of a single spin channel if input
-    !! by the user
   integer, allocatable :: iType(:)
     !! Atom type index
   integer :: fftGridSize(3)
@@ -116,9 +113,6 @@ module wfcExportVASPMod
   logical :: groupForGroupVelocity
     !! If there are groups of k-points for group
     !! velocity calculation
-  logical :: loopSpins
-    !! Whether to loop over available spin channels;
-    !! otherwise, use selected spin channel
   
   character(len=256) :: exportDir
     !! Directory to be used for export

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -3640,7 +3640,7 @@ module wfcExportVASPMod
   end subroutine writePseudoInfo
 
 !----------------------------------------------------------------------------
-  subroutine writeEigenvalues(nBands, nKPoints, nSpins, bandOccupation, eFermi, eTot, eigenE)
+  subroutine writeEigenvalues(ispSelect, nBands, nKPoints, nSpins, bandOccupation, eFermi, eTot, eigenE, loopSpins)
     !! Write Fermi energy and eigenvalues and occupations for each band
 
     use miscUtilities, only: int2str
@@ -3648,6 +3648,9 @@ module wfcExportVASPMod
     implicit none
 
     ! Input variables:
+    integer, intent(in) :: ispSelect
+      !! Selection of a single spin channel if input
+      !! by the user
     integer, intent(in) :: nBands
       !! Total number of bands
     integer, intent(in) :: nKPoints
@@ -3664,6 +3667,10 @@ module wfcExportVASPMod
 
     complex*16, intent(in) :: eigenE(nSpins,nKPoints,nBands)
       !! Band eigenvalues
+
+    logical, intent(in) :: loopSpins
+      !! Whether to loop over available spin channels;
+      !! otherwise, use selected spin channel
 
     ! Local variables:
     integer :: ik, ib, isp

--- a/Export/VASP/src/Export_VASP_module.f90
+++ b/Export/VASP/src/Export_VASP_module.f90
@@ -340,8 +340,8 @@ module wfcExportVASPMod
       abortExecution = checkStringInitialization('pattern', pattern) .or. abortExecution
     endif
 
-    if(checkIntInitialization('ispSelect', ispSelect, 1, 2)) then
-      write(*,*) "Looping over spin."
+    if(ispSelect < 1 .or. ispSelect > 2) then
+      write(*,*) "No valid choice for spin channel selection given. Looping over spin."
       loopSpins = .true.
     else
       write(*,'("Only exporting spin channel ", i2)') ispSelect

--- a/TME/README.md
+++ b/TME/README.md
@@ -19,6 +19,9 @@ The `TME` input file for the zeroth-order should look like
 &TME_Input
   ! Which order of matrix element to calculate
   order = 0
+
+  ! Spin channel selection; default unused
+  ispSelect = integer  
   
   ! Systems used for overlaps
   exportDirSD    = 'path-to-final-charge-state-initial-positions-export'
@@ -50,6 +53,9 @@ The `TME` input file for the first-order term should look like
 &TME_Input
   ! Which order of matrix element to calculate
   order = 1
+
+  ! Spin channel selection; default unused
+  ispSelect = integer                                   
   
   ! Systems used for overlaps
   exportDirSD    = 'path-to-displaced-defect-export'

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -35,7 +35,8 @@ program TMEmain
   call cpu_time(t1)
 
 
-  call readInput(maxAngMom, maxGIndexGlobal, nKPoints, nGVecsGlobal, realLattVec, recipLattVec, baselineDir, subtractBaseline)
+  call readInput(ispSelect, maxAngMom, maxGIndexGlobal, nKPoints, nGVecsGlobal, realLattVec, recipLattVec, baselineDir, &
+        loopSpins, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     !! @todo Figure out if `realLattVec` used anywhere. If not remove. @endtodo

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -8,6 +8,8 @@ program TMEmain
 
   logical :: calcSpinDepSD, calcSpinDepPC
     !! If spin-dependent subroutines should be called
+  logical :: spin1Skipped
+    !! If the first spin channel was skipped
   logical :: thisKComplete = .false.
     !! If needed `allElecOverlap.isp.ik` files exist
     !! at the current k-point
@@ -148,12 +150,14 @@ program TMEmain
       
       do isp = 1, nSpins
 
-        if(loopSpins .or. isp == ispSelect) then
+        if(isp == 1 .and. (ispSelect == 2 .or. overlapFileExists(ikGlobal,1))) then
+          spin1Skipped = .true.
+        else if(loopSpins .or. isp == ispSelect) then
 
           if(ionode) write(*,'("  Beginning spin ", i2)') isp
 
-          calcSpinDepPC = (isp == 1) .or. (nSpinsPC == 2 .and. (ispSelect == 2 .or. overlapFileExists(ikGlobal,1)))
-          calcSpinDepSD = (isp == 1) .or. (nSpinsSD == 2 .and. (ispSelect == 2 .or. overlapFileExists(ikGlobal,1)))
+          calcSpinDepPC = isp == 1 .or. nSpinsPC == 2 .or. spin1Skipped
+          calcSpinDepSD = isp == 1 .or. nSpinsSD == 2 .or. spin1Skipped
             ! If either of the systems only has a single spin 
             ! channel, some inputs and calculations do not need
             ! to be redone for both spin channels. However, we

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -332,7 +332,13 @@ contains
       abortExecution = checkFileInitialization('dqFName', dqFName) .or. abortExecution
       abortExecution = checkIntInitialization('phononModeJ', phononModeJ, 1, int(1e9)) .or. abortExecution
 
-      if(subtractBaseline) abortExecution = checkDirInitialization('baselineDir', baselineDir, 'allElecOverlap.1.1') .or. abortExecution
+      if(subtractBaseline) then
+        if(ispSelect == 2) then
+          abortExecution = checkDirInitialization('baselineDir', baselineDir, 'allElecOverlap.2.1') .or. abortExecution
+        else
+          abortExecution = checkDirInitialization('baselineDir', baselineDir, 'allElecOverlap.1.1') .or. abortExecution
+        endif
+      endif
     endif
 
     if(ispSelect < 1 .or. ispSelect > 2) then

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -183,7 +183,7 @@ contains
     
       if(ierr /= 0) call exitError('readInputParams', 'reading TME_Input namelist', abs(ierr))
     
-      call checkInitialization(ispSelect, baselineDir, loopSpins, subtractBaseline)
+      call checkInitialization(ispSelect, baselineDir, subtractBaseline, loopSpins)
 
     endif
 
@@ -295,11 +295,11 @@ contains
   end subroutine initialize
   
 !----------------------------------------------------------------------------
-  subroutine checkInitialization(ispSelect, baselineDir, loopSpins, subtractBaseline)
+  subroutine checkInitialization(ispSelect, baselineDir, subtractBaseline, loopSpins)
     
     implicit none
 
-    ! Output variables:
+    ! Input variables:
     integer, intent(in) :: ispSelect
       !! Selection of a single spin channel if input
       !! by the user
@@ -308,13 +308,15 @@ contains
       !! File name for baseline overlap to optionally
       !! be subtracted for the first-order term
 
-    logical, intent(out) :: loopSpins
-      !! Whether to loop over available spin channels;
-      !! otherwise, use selected spin channel
     logical, intent(in) :: subtractBaseline
       !! If baseline should be subtracted from first-order
       !! overlap for increased numerical accuracy in the 
       !! derivative
+
+    ! Output variables:
+    logical, intent(out) :: loopSpins
+      !! Whether to loop over available spin channels;
+      !! otherwise, use selected spin channel
     
     ! Local variables
     logical :: abortExecution

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -433,9 +433,10 @@ contains
       enddo
     
       read(50, '(a)') textDum
-      read(50,*) nBands
+      read(50,'(i10)') nBands
 
-      if(iBandIfinal > nBands .or. iBandFfinal) call exitError('readInputPC', 'band limits outside the number of bands in the system', 1)
+      if(iBandIfinal > nBands .or. iBandFfinal > nBands) &
+        call exitError('readInputPC', 'band limits outside the number of bands in the system '//trim(int2str(nBands)), 1)
         ! Only need to test these bands because we tested in
         ! the `checkInitialization` subroutine to make sure
         ! that the `initial` bands are lower than the `final`
@@ -720,9 +721,10 @@ contains
       enddo
     
       read(50, '(a)') textDum
-      read(50,*) nBands
+      read(50,'(i10)') nBands
 
-      if(iBandIfinal > nBands .or. iBandFfinal) call exitError('readInputPC', 'band limits outside the number of bands in the system', 1)
+      if(iBandIfinal > nBands .or. iBandFfinal > nBands) &
+        call exitError('readInputSD', 'band limits outside the number of bands in the system '//trim(int2str(nBands)), 1)
         ! Only need to test these bands because we tested in
         ! the `checkInitialization` subroutine to make sure
         ! that the `initial` bands are lower than the `final`

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -77,7 +77,7 @@ module TMEmod
   integer :: iTypes, iPn
   integer :: nIonsSD, nIonsPC, nProjsPC, numOfTypesPC
   integer :: numOfTypes, nProjsSD
-  integer :: numOfUsedGvecsPP, ios, npwNi, npwNf, npwMi, npwMf
+  integer :: numOfUsedGvecsPP, npwNi, npwNf, npwMi, npwMf
   integer :: np, nI, nF, nPP, ind2
   integer :: i, j, n1, n2, n3, n4, n, id, npw
   
@@ -171,7 +171,9 @@ contains
     
       call initialize(baselineDir, subtractBaseline)
     
-      read(5, TME_Input, iostat=ios)
+      read(5, TME_Input, iostat=ierr)
+    
+      if(ierr /= 0) call exitError('readInputParams', 'reading TME_Input namelist', abs(ierr))
     
       call checkInitialization(baselineDir, subtractBaseline)
 


### PR DESCRIPTION
Previously, only LSF allowed selecting a single spin channel. This may not be needed for scattering, but it is useful, especially for capture, to have the option to loop over spin or select a single spin. I implemented the option to select the spin channel in `Export`, `TME`, and `EnergyTabulator`. The other programs do not utilize spin or were already implemented. 