### PR TITLE
Add menu to PhononPP and add option to check convergence

### DIFF
--- a/CommonModules/cell.f90
+++ b/CommonModules/cell.f90
@@ -24,7 +24,7 @@ module cell
   contains
 
 !----------------------------------------------------------------------------
-  function cartDispProjOnPhononEigsNorm(j, nAtoms, displacement, eigenvector, mass) result(projNorm)
+  function cartDispProjOnPhononEigsNorm(nAtoms, displacement, eigenvector, mass, realLattVec) result(projNorm)
     !! Project the displacement onto the phonon eigenvectors
     !! and return the norm of that projection across all atoms
 
@@ -40,6 +40,8 @@ module cell
       !! Eigenvectors for each atom for a single mode
     real(kind=dp), intent(in) :: mass(nAtoms)
       !! Masses of atoms
+    real(kind=dp), intent(in) :: realLattVec(3,3)
+      !! Real space lattice vectors
 
     ! Output variables:
     real(kind=dp) :: projNorm
@@ -48,7 +50,7 @@ module cell
 
 
     ! Local variables:
-    integer :: ia, j
+    integer :: ia
       !! Loop index
 
     real(kind=dp) :: eig(3)
@@ -79,6 +81,7 @@ module cell
       eigDotEig = eigDotEig + dot_product(eig,eig)
 
     enddo
+
 
     proj(:,:) = genDispDotEig/eigDotEig*eigenvector(:,:)
 

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -16,6 +16,7 @@ There are two cases that `PhononPP` can be run with: a single displacement (e.g.
   dqFName          = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
 
   shift = shift-magnitude                ! Real (Angstrom), default 0.01 A
+  freqThresh = frequency-threshold       ! Threshold for keeping frequencies, default 0.5 (same units as Phononpy)
 
   generateShiftedPOSCARs = logical       ! Logical, default .true.
   prefix           = 'prefix-for-shifted-poscars'              ! Default: './ph_POSCAR'; ignored if .not. generateShiftedPOSCARs
@@ -39,6 +40,7 @@ For a range of displacements, the inputs should look like
   dqFName          = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
 
   shift = shift-magnitude                ! Real (Angstrom), default 0.01 A
+  freqThresh = frequency-threshold       ! Threshold for keeping frequencies, default 0.5 (same units as Phononpy)
 
   generateShiftedPOSCARs = logical       ! Logical, default .true.
   prefix           = 'prefix-for-shifted-poscars'              ! Default: './ph_POSCAR'; ignored if .not. generateShiftedPOSCARs

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -9,18 +9,23 @@ There are two cases that `PhononPP` can be run with: a single displacement (e.g.
 &inputParams
   singleDisp = .true.             ! If there's a single displacement to consider, default .true.
 
+  ! Required to read phonons:
+  phononFName      = 'path-to-phonopy-output-yaml-file'        ! Default: './mesh.yaml'
+  freqThresh = frequency-threshold       ! Threshold for keeping frequencies, default 0.5 (same units as Phononpy)
+
+  ! Calculating Sj
+  calcSj           = logical                                   ! Default: .true.; if Sj should be calculated
   initPOSCARFName  = 'path-to-init-poscar'                     ! Default: './POSCAR_init'
   finalPOSCARFName = 'path-to-final-poscar'                    ! Default: './POSCAR_final'
 
-  phononFName      = 'path-to-phonopy-output-yaml-file'        ! Default: './mesh.yaml'
-  dqFName          = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
+  ! Calculating dq:
+  dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
+  shift   = shift-magnitude                           ! Real (Angstrom), default 0.01 A
 
-  shift = shift-magnitude                ! Real (Angstrom), default 0.01 A
-  freqThresh = frequency-threshold       ! Threshold for keeping frequencies, default 0.5 (same units as Phononpy)
-
-  generateShiftedPOSCARs = logical       ! Logical, default .true.
-  prefix           = 'prefix-for-shifted-poscars'              ! Default: './ph_POSCAR'; ignored if .not. generateShiftedPOSCARs
-  basePOSCARFName = 'path-to-base-poscar'                      ! Default: initPOSCARFName; optional to use as base for shift
+  ! Generating shifted POSCARs:
+  generateShiftedPOSCARs = logical                         ! Logical, default .true.
+  prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
+  basePOSCARFName        = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
 /
 ```
 
@@ -30,21 +35,26 @@ For a range of displacements, the inputs should look like
 &inputParams
   singleDisp = .false.             ! If there's a single displacement to consider, default .true.
 
-  CONTCARsBaseDir  = 'path-to-base-dir-for-relaxed-positions'   
-  iBandIinit = integer						! lowest initial-state band
-  iBandIfinal = integer						! highest initial-state band
-  iBandFinit = integer						! lowest final-state band
-  iBandFfinal = integer						! highest final-state band
-
+  ! Required to read phonons:
   phononFName      = 'path-to-phonopy-output-yaml-file'        ! Default: './mesh.yaml'
-  dqFName          = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
-
-  shift = shift-magnitude                ! Real (Angstrom), default 0.01 A
   freqThresh = frequency-threshold       ! Threshold for keeping frequencies, default 0.5 (same units as Phononpy)
 
-  generateShiftedPOSCARs = logical       ! Logical, default .true.
-  prefix           = 'prefix-for-shifted-poscars'              ! Default: './ph_POSCAR'; ignored if .not. generateShiftedPOSCARs
-  basePOSCARFName = 'path-to-base-poscar'                      ! Required when considering multiple displacements
+  ! Calculating Sj
+  calcSj           = logical                                   ! Default: .true.; if Sj should be calculated
+  CONTCARsBaseDir  = 'path-to-base-dir-for-relaxed-positions'   
+  iBandIinit       = integer						! lowest initial-state band
+  iBandIfinal      = integer						! highest initial-state band
+  iBandFinit       = integer						! lowest final-state band
+  iBandFfinal      = integer						! highest final-state band
+
+  ! Calculating dq:
+  dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
+  shift   = shift-magnitude                           ! Real (Angstrom), default 0.01 A
+
+  ! Generating shifted POSCARs:
+  generateShiftedPOSCARs = logical                         ! Logical, default .true.
+  prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
+  basePOSCARFName        = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
 /
 ```
 

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -25,8 +25,12 @@ There are two cases that `PhononPP` can be run with: a single displacement (e.g.
   ! Generating shifted POSCARs:
   generateShiftedPOSCARs = logical                         ! Logical, default .true.
   prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
+  
+  ! Calculating max displacement:
+  calcMaxDisp = logical               ! Default .false.; if max displacement between two atoms across modes should be calculated
+  dispInd     = int1, int2            ! Two integers for indices of atoms to get relative displacement for each mode             
 
-  ! Needed to get dq and shifted POSCARs:
+  ! Needed to get dq and shifted POSCARs and calculating max displacement:
   basePOSCARFName = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
   shift           = shift-magnitude                 ! Real (Angstrom), default 0.01 A
 /
@@ -58,7 +62,11 @@ For a range of displacements, the inputs should look like
   generateShiftedPOSCARs = logical                         ! Logical, default .true.
   prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
 
-  ! Needed to get dq and shifted POSCARs:
+  ! Calculating max displacement:
+  calcMaxDisp = logical               ! Default .false.; if max displacement between two atoms across modes should be calculated
+  dispInd     = int1, int2            ! Two integers for indices of atoms to get relative displacement for each mode             
+
+  ! Needed to get dq and shifted POSCARs and calculating max displacement:
   basePOSCARFName = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
   shift           = shift-magnitude                 ! Real (Angstrom), default 0.01 A
 /

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -20,12 +20,14 @@ There are two cases that `PhononPP` can be run with: a single displacement (e.g.
 
   ! Calculating dq:
   dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
-  shift   = shift-magnitude                           ! Real (Angstrom), default 0.01 A
 
   ! Generating shifted POSCARs:
   generateShiftedPOSCARs = logical                         ! Logical, default .true.
   prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
-  basePOSCARFName        = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
+
+  ! Needed to get dq and shifted POSCARs:
+  basePOSCARFName = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
+  shift           = shift-magnitude                 ! Real (Angstrom), default 0.01 A
 /
 ```
 
@@ -49,12 +51,14 @@ For a range of displacements, the inputs should look like
 
   ! Calculating dq:
   dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
-  shift   = shift-magnitude                           ! Real (Angstrom), default 0.01 A
 
   ! Generating shifted POSCARs:
   generateShiftedPOSCARs = logical                         ! Logical, default .true.
   prefix                 = 'prefix-for-shifted-poscars'    ! Default: './ph_POSCAR'
-  basePOSCARFName        = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
+
+  ! Needed to get dq and shifted POSCARs:
+  basePOSCARFName = 'path-to-base-poscar'           ! Default: './POSCAR_init'; base to shift from
+  shift           = shift-magnitude                 ! Real (Angstrom), default 0.01 A
 /
 ```
 

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -19,6 +19,7 @@ There are two cases that `PhononPP` can be run with: a single displacement (e.g.
   finalPOSCARFName = 'path-to-final-poscar'                    ! Default: './POSCAR_final'
 
   ! Calculating dq:
+  calcDq  = logical                                   ! Default: .true.; if dq output file should be generated
   dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
 
   ! Generating shifted POSCARs:
@@ -50,6 +51,7 @@ For a range of displacements, the inputs should look like
   iBandFfinal      = integer						! highest final-state band
 
   ! Calculating dq:
+  calcDq  = logical                                   ! Default: .true.; if dq output file should be generated
   dqFName = 'file-to-output-generalized-coord-norms'  ! Default: './dq.txt'
 
   ! Generating shifted POSCARs:

--- a/PhononPP/src/Makefile
+++ b/PhononPP/src/Makefile
@@ -4,6 +4,8 @@
 # location of needed modules
 MODFLAGS= -I$(CommonModules_srcPath) -I.
 
+DEBUGFLAGS = -check all -g -warn all -traceback -gen-interfaces 
+
 PHONONPP_OBJS = PhononPP_module.o PhononPP_main.o
 COMMONMODS = $(CommonModules_srcPath)/commonmodules.a
 
@@ -25,6 +27,7 @@ mods :
 
 %.o : %.f90
 	$(mpif90) $(MODFLAGS) -O3 -c -assume byterecl -fpp $<
+	#$(mpif90) $(MODFLAGS) $(DEBUGFLAGS) -O0 -c -assume byterecl -fpp $<
 
 clean :
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -14,54 +14,27 @@ program PhononPPMain
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
         phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcSj, generateShiftedPOSCARs, singleDisp)
 
-  ! Read one initial POSCAR to get the number of atoms
-  if(ionode) then
 
-    ! If calculating Sj, will either have initPOSCARFName or CONTCARsBaseDir
-    if(calcSj .and. .not. singleDisp) initPOSCARFName = trim(CONTCARsBaseDir)//'/'//trim(int2str(iBandIinit))//'/CONTCAR'
-    ! Otherwise, must be calculating shifted POSCARs, so we will have basePOSCARFName
-    if(.not. calcSj) initPOSCARFName = trim(basePOSCARFName)
-
-    call readPOSCAR(initPOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
-    call standardizeCoordinates(nAtoms, atomPositionsDirInit)
-
-  endif
-
-
-  ! Broadcast atom number and cell parameters
-  call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
-  if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
-  call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-
-
-  ! Get the number of modes, read the phonons, and distribute
-  ! across the proceses
-  nModes = 3*nAtoms - 3
-
-  allocate(eigenvector(3,nAtoms,nModes))
-  allocate(mass(nAtoms))
-  allocate(omegaFreq(nModes))
-
-  call readPhonons(nAtoms, nModes, atomPositionsDirInit, freqThresh, phononFName, eigenvector, mass, omegaFreq)
-
-  deallocate(atomPositionsDirInit)
+  call readPhonons(freqThresh, phononFName, nAtoms, nModes, coordFromPhon, eigenvector, mass, omegaFreq)
 
   call distributeItemsInSubgroups(myid, nModes, nProcs, nProcs, nProcs, iModeStart, iModeEnd, nModesLocal)
 
 
   if(calcSj) &
-    call calculateSj(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, nAtoms, nModes, eigenvector, mass, omegaFreq, singleDisp, & 
-        CONTCARsBaseDir, initPOSCARFName, finalPOSCARFName)
+    call calculateSj(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, nAtoms, nModes, coordFromPhon, eigenvector, mass, &
+          omegaFreq, singleDisp, CONTCARsBaseDir, initPOSCARFName, finalPOSCARFName)
 
 
   deallocate(omegaFreq)
 
 
-  call calculateShiftAndDq(nAtoms, nModes, eigenvector, mass, shift, generateShiftedPOSCARs, basePOSCARFName, dqFName, prefix)
+  call calculateShiftAndDq(nAtoms, nModes, coordFromPhon, eigenvector, mass, shift, generateShiftedPOSCARs, & 
+        basePOSCARFName, dqFName, prefix)
 
 
-  deallocate(mass)
+  deallocate(coordFromPhon)
   deallocate(eigenvector)
+  deallocate(mass)
 
 
   call MPI_Barrier(worldComm, ierr)

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -39,7 +39,7 @@ program PhononPPMain
   allocate(mass(nAtoms))
   allocate(omegaFreq(nModes))
 
-  call readPhonons(nAtoms, nModes, atomPositionsDirInit, phononFName, eigenvector, mass, omegaFreq)
+  call readPhonons(nAtoms, nModes, atomPositionsDirInit, freqThresh, phononFName, eigenvector, mass, omegaFreq)
 
   deallocate(atomPositionsDirInit)
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -9,8 +9,9 @@ program PhononPPMain
 
   call mpiInitialization('PhononPP')
 
-  call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
-        phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcDq, calcSj, generateShiftedPOSCARs, singleDisp)
+  call readInputs(dispInd, iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, &
+        CONTCARsBaseDir, dqFName, phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcDq, calcMaxDisp, calcSj, & 
+        generateShiftedPOSCARs, singleDisp)
 
 
   call readPhonons(freqThresh, phononFName, nAtoms, nModes, coordFromPhon, eigenvector, mass, omegaFreq)
@@ -26,9 +27,9 @@ program PhononPPMain
   deallocate(omegaFreq)
 
 
-  if(calcDq .or. generateShiftedPOSCARs) &
-    call calculateShiftAndDq(nAtoms, nModes, coordFromPhon, eigenvector, mass, shift, calcDq, generateShiftedPOSCARs, & 
-        basePOSCARFName, dqFName, prefix)
+  if(calcDq .or. generateShiftedPOSCARs .or. calcMaxDisp) &
+    call calculateShiftAndDq(dispInd, nAtoms, nModes, coordFromPhon, eigenvector, mass, shift, calcDq, calcMaxDisp, &
+          generateShiftedPOSCARs, basePOSCARFName, dqFName, prefix)
 
 
   deallocate(coordFromPhon)

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -4,8 +4,6 @@ program PhononPPMain
   
   implicit none
 
-  integer :: j
-    !! Loop indices
 
   call cpu_time(t0)
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -11,7 +11,7 @@ program PhononPPMain
 
   call mpiInitialization('PhononPP')
 
-  call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
+  call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
         phononFName, finalPOSCARFName, initPOSCARFName, prefix, generateShiftedPOSCARs, singleDisp)
 
   ! Read one initial POSCAR to get the number of atoms

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -12,7 +12,7 @@ program PhononPPMain
   call mpiInitialization('PhononPP')
 
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
-        phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcSj, generateShiftedPOSCARs, singleDisp)
+        phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcDq, calcSj, generateShiftedPOSCARs, singleDisp)
 
 
   call readPhonons(freqThresh, phononFName, nAtoms, nModes, coordFromPhon, eigenvector, mass, omegaFreq)
@@ -28,7 +28,8 @@ program PhononPPMain
   deallocate(omegaFreq)
 
 
-  call calculateShiftAndDq(nAtoms, nModes, coordFromPhon, eigenvector, mass, shift, generateShiftedPOSCARs, & 
+  if(calcDq .or. generateShiftedPOSCARs) &
+    call calculateShiftAndDq(nAtoms, nModes, coordFromPhon, eigenvector, mass, shift, calcDq, generateShiftedPOSCARs, & 
         basePOSCARFName, dqFName, prefix)
 
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -7,7 +7,7 @@ program PhononPPMain
   
   implicit none
 
-  integer :: j, ibi, ibf
+  integer :: j
     !! Loop indices
 
   call cpu_time(t0)
@@ -30,9 +30,6 @@ program PhononPPMain
 
   ! Broadcast atom number and cell parameters
   call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
-  call MPI_BCAST(omega, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-  call MPI_BCAST(realLattVec, size(realLattVec), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-
   if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
   call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
@@ -45,63 +42,15 @@ program PhononPPMain
   allocate(mass(nAtoms))
   allocate(omegaFreq(nModes))
 
-  call readPhonons(nAtoms, nModes, phononFName, eigenvector, mass, omegaFreq)
+  call readPhonons(nAtoms, nModes, atomPositionsDirInit, phononFName, eigenvector, mass, omegaFreq)
+
+  deallocate(atomPositionsDirInit)
 
   call distributeItemsInSubgroups(myid, nModes, nProcs, nProcs, nProcs, iModeStart, iModeEnd, nModesLocal)
 
 
-  if(singleDisp) then
-
-    SjFName = 'Sj.out'
-    call getSingleDisp(nAtoms, nModes, atomPositionsDirInit, eigenvector, mass, omega, omegaFreq, finalPOSCARFName, SjFName)
-
-    deallocate(atomPositionsDirInit)
-
-  else
-
-    ! I do a loop over all of the bands. Depending on the band selection,
-    ! this could result in duplicate pairs (e.g., .1.2 and .2.1), but I 
-    ! can't think of a general way to exlude these pairs without a significant
-    ! amount of work to track the pairs that have already been calcualted.
-    ! Any solution I can think of would not hold for both hole and electron
-    ! capture and/or different ranges of bands selected by the user. For
-    ! now, I just have the code output all of the duplicate pairs and the
-    ! user/LSF code can use whatever they need from that.
-    do ibi = iBandIinit, iBandIfinal
-
-      ! Get the initial positions for this band (unless we did
-      ! it earlier)
-      if(ibi /= iBandIinit) then
-        if(ionode) then
-          initPOSCARFName = trim(CONTCARsBaseDir)//'/'//trim(int2str(ibi))//'/CONTCAR'
-
-          call readPOSCAR(initPOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
-          call standardizeCoordinates(nAtoms, atomPositionsDirInit)
-        endif
-
-        if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
-        call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-      endif
-
-      do ibf = iBandFinit, iBandFfinal
-
-        if(ibf /= ibi) then
-          ! Set the final positions and output file names
-          finalPOSCARFName = trim(CONTCARsBaseDir)//'/'//trim(int2str(ibf))//'/CONTCAR'
-          SjFName = 'Sj.'//trim(int2str(ibi))//'.'//trim(int2str(ibf))//'.out'
-
-          ! Get displacement and output ranked Sj for a single pair of states
-          call getSingleDisp(nAtoms, nModes, atomPositionsDirInit, eigenvector, mass, omega, omegaFreq, finalPOSCARFName, SjFName)
-
-        endif
-      enddo
-
-      ! Positions are allocated in readPOSCAR, so we need to 
-      ! deallocate them after every loop
-      deallocate(atomPositionsDirInit)
-    enddo
-
-  endif
+  call calculateSj(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, nAtoms, nModes, eigenvector, mass, omegaFreq, singleDisp, & 
+        CONTCARsBaseDir, initPOSCARFName, finalPOSCARFName)
 
 
   deallocate(omegaFreq)
@@ -124,19 +73,17 @@ program PhononPPMain
 
 
 
-  if(generateShiftedPOSCARs) then
-    ! Read base POSCAR to shift from
-    if(ionode) then
+  if(ionode) then
 
-    call readPOSCAR(basePOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
-    call standardizeCoordinates(nAtoms, atomPositionsDirInit)
-
-    endif
-
-    if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
-    call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+  call readPOSCAR(basePOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
+  call standardizeCoordinates(nAtoms, atomPositionsDirInit)
 
   endif
+
+  call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
+  if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
+  call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+  call MPI_BCAST(realLattVec, size(realLattVec), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
 
   ! Get the displacement for each mode to 
@@ -156,9 +103,9 @@ program PhononPPMain
 
   do j = iModeStart, iModeEnd
 
-    displacement = getShiftDisplacement(nAtoms, eigenvector(:,:,j), mass, shift)
+    displacement = getShiftDisplacement(nAtoms, eigenvector(:,:,j), realLattVec, mass, shift)
 
-    projNorm(j) = cartDispProjOnPhononEigsNorm(j, nAtoms, displacement, eigenvector(:,:,j), mass)
+    projNorm(j) = cartDispProjOnPhononEigsNorm(nAtoms, displacement, eigenvector(:,:,j), mass, realLattVec)
 
     if(generateShiftedPOSCARs) then
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -12,12 +12,15 @@ program PhononPPMain
   call mpiInitialization('PhononPP')
 
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, freqThresh, shift, basePOSCARFName, CONTCARsBaseDir, dqFName, &
-        phononFName, finalPOSCARFName, initPOSCARFName, prefix, generateShiftedPOSCARs, singleDisp)
+        phononFName, finalPOSCARFName, initPOSCARFName, prefix, calcSj, generateShiftedPOSCARs, singleDisp)
 
   ! Read one initial POSCAR to get the number of atoms
   if(ionode) then
 
-    if(.not. singleDisp) initPOSCARFName = trim(CONTCARsBaseDir)//'/'//trim(int2str(iBandIinit))//'/CONTCAR'
+    ! If calculating Sj, will either have initPOSCARFName or CONTCARsBaseDir
+    if(calcSj .and. .not. singleDisp) initPOSCARFName = trim(CONTCARsBaseDir)//'/'//trim(int2str(iBandIinit))//'/CONTCAR'
+    ! Otherwise, must be calculating shifted POSCARs, so we will have basePOSCARFName
+    if(.not. calcSj) initPOSCARFName = trim(basePOSCARFName)
 
     call readPOSCAR(initPOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
     call standardizeCoordinates(nAtoms, atomPositionsDirInit)
@@ -46,7 +49,8 @@ program PhononPPMain
   call distributeItemsInSubgroups(myid, nModes, nProcs, nProcs, nProcs, iModeStart, iModeEnd, nModesLocal)
 
 
-  call calculateSj(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, nAtoms, nModes, eigenvector, mass, omegaFreq, singleDisp, & 
+  if(calcSj) &
+    call calculateSj(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, nAtoms, nModes, eigenvector, mass, omegaFreq, singleDisp, & 
         CONTCARsBaseDir, initPOSCARFName, finalPOSCARFName)
 
 

--- a/PhononPP/src/PhononPP_module.f90
+++ b/PhononPP/src/PhononPP_module.f90
@@ -396,7 +396,7 @@ module PhononPPMod
     endif
 
 
-    call MPI_BCAST(nAtoms, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+    call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
     allocate(coordFromPhon(3,nAtoms))
     allocate(mass(nAtoms))
 
@@ -549,15 +549,15 @@ module PhononPPMod
       if(ionode) then
         call readPOSCAR(initPOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
         call standardizeCoordinates(nAtoms, atomPositionsDirInit)
-
-        call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirInit, displacement)
       endif
 
-      call MPI_BCAST(nAtoms, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+      call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
 
       if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
       call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
       call MPI_BCAST(omega, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+
+      call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirInit, displacement)
 
       SjFName = 'Sj.out'
       call getSingleDisp(nAtoms, nModes, atomPositionsDirInit, eigenvector, mass, omega, omegaFreq, finalPOSCARFName, SjFName)
@@ -582,14 +582,14 @@ module PhononPPMod
 
           call readPOSCAR(initPOSCARFName, nAtoms, atomPositionsDirInit, omega, realLattVec)
           call standardizeCoordinates(nAtoms, atomPositionsDirInit)
-
-          call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirInit, displacement)
         endif
 
-        call MPI_BCAST(nAtoms, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+        call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
 
         if(.not. ionode) allocate(atomPositionsDirInit(3,nAtoms))
         call MPI_BCAST(atomPositionsDirInit, size(atomPositionsDirInit), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+
+        call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirInit, displacement)
 
         do ibf = iBandFinit, iBandFfinal
 
@@ -736,6 +736,7 @@ module PhononPPMod
 
 
     if(ionode) then
+
       abortExecution = .false.
 
       do ia= 1, nAtoms
@@ -969,8 +970,6 @@ module PhononPPMod
       call readPOSCAR(basePOSCARFName, nAtoms, atomPositionsDirBase, omega, realLattVec)
       call standardizeCoordinates(nAtoms, atomPositionsDirBase)
 
-      call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirBase, displacement)
-
     endif
 
     call MPI_BCAST(nAtoms, 1, MPI_INTEGER, root, worldComm, ierr)
@@ -978,10 +977,13 @@ module PhononPPMod
     call MPI_BCAST(atomPositionsDirBase, size(atomPositionsDirBase), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
     call MPI_BCAST(realLattVec, size(realLattVec), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
+    allocate(displacement(3,nAtoms))
+
+    call getRelaxDispAndCheckCompatibility(nAtoms, coordFromPhon, atomPositionsDirBase, displacement)
+
 
     allocate(shiftedPositions(3,nAtoms))
     allocate(projNorm(nModes))
-    allocate(displacement(3,nAtoms))
     projNorm = 0.0_dp
 
     write(memoLine,'("  shift = ", ES9.2E1)') shift


### PR DESCRIPTION
There are multiple features that the user may want to use when post-processing the phonons, so this change adapts the main program to be like a menu where the user can select what parts to complete and what parts to skip. By default, the code runs as it did before the menu options were added. 

I also added the ability to check the maximum relative displacement between a given pair of atoms across all of the phonon eigenvectors for a given shift size. The maximum displacement and mode are output to the main output file. 

To be more complete, the code would figure out the nearest neighbors for atoms (could read from the OUTCAR), then calculate the relative displacements for each set and find the max across atoms and modes without having to select two atoms. You could also go ahead and generate the shifted POSCARs for two different shift sizes for testing convergence. However, right now that would take too long to be worth it. 

Instead, my thought is just to have the user run the code multiple times with different shift sizes as needed to check convergence and to get the maximum relative displacement between different atoms.