### PR TITLE
Add rk4 real-time integration

### DIFF
--- a/LSF/README.md
+++ b/LSF/README.md
@@ -3,8 +3,13 @@
 The `LSF` program takes in matrix elements, an energy table, the Huang-Rhys factor, and the phonon frequencies and occupation numbers and performs the time-domain integration to get the final transition rate. Before this code can run, you need to run the `TME` program for the proper-order matrix elements, the `EnergyTabulator` program to get the band bounds and table of energies for the delta function, and the `PhononPP` program that post-processes the phonons to get the Huang-Rhys factors and phonon frequencies and occupations. 
 
 The output files are 
-  * `transitionRate.isp.ik`/`transitionRate.isp` -- initial band index and transition rate (1/s) (k-point index not present for scattering)
-  * `nj.new.out` -- new occupations for scattering with the `generateNewOccupations` option
+  * `transitionRate.isp.ik`/`transitionRate.isp`/`transitionRate.isp.iRt`, where `iRt` is the real-time-integration index
+     * initial band index and transition rate (1/s) (k-point index not present for scattering)
+     * stored in `transRateOutDir`, which defaults to `'./transitionRates'`
+  * `nj.iRt.out`, where `iRt` is the real-time-integration index
+     * new occupations and occupation rates of change for scattering with the `generateNewOccupations` option
+     * *Note that the first step is the initial occupations and the rate of change at the first step.*
+     * stored in `njNewOutDir`, which defaults to `'./njNew'`
   * stdout -- timing information and status updates
 
 ## Inputs
@@ -33,7 +38,7 @@ Every calculation must have the following inputs:
 * `hbarGamma` -- default `0.0`; determines smearing of integrand based on $\exp(-\gamma \tau)$ to achieve convergence
 * `smearingExpTolerance` -- default `0.0`; max time for integration is determined by this threshold set on the smearing exponential
 * `diffOmega` -- default `.false.`; if there is a different frequency before and after transition; only currently tested for capture; should be consistent with `PhononPP` output
-* `outputDir` -- default `'./'`; where to output transition-rate files
+* `transRateOutDir` -- default `'./transitionRates'`; where to output transition-rate files
 
 *There is an option to input `SjThresh`, but that input is not fully tested, so don't use it!* There is also an `oldFormat` option that can be useful if you are updating the code and needing to run `LSF` with two different formats. This option will most likely not be used, though.
 
@@ -52,8 +57,10 @@ For scattering (`captured = .false.`), there are several additional options:
 * `deltaNjBaseDir` -- path to the changes in occupations for carrier approach, transition, and departure (output by `PhononPP`)
 * `generateNewOccupations` -- if average over transitions should be performed and new occupations should be calculated
 * `dt` -- default `1e-4` **(s)**; real-time step to be multiplied by average rate of change of occupations to get $\Delta \bar{n}_j$
+* `nRealTimeSteps` -- default `1`; number of real time steps to take if `generateNewOccupations = .true.`
 * `carrierDensityInput` -- path to carrier density file used to perform integration over initial states
 * `energyAvgWindow` -- default `1e-2` eV; energy window over which to average noisy carrier-density input
+* `njNewOutDir` -- default `'./njNew'`; where to store new occupation files
 
 Note that all of our code is in Hartree atomic units until the calculation of the new occupations. The energies from the band edge given in `dEPlot.isp` are in eV and the carrier density is in $\mathrm{cm}^{-3}$ $\mathrm{eV}^{-1}$, so the `energyAvgWindow` for evaluating the carrier density at the energies in `dEPlot.isp` is in eV. After integration over the initial states multiplied by the carrier density as a function of energy, the resulting rate of change of the occupations is in $\mathrm{s}^{-1}$, so the time step `dt` for the real-time integration of the occupations is in s. 
 

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -124,7 +124,7 @@ program LSFmain
   ! Only pass a slice over transitions  here because we know for scattering
   ! there is no parallelization over k-points.
   if(generateNewOccupations) &
-    call calcAndWriteNewOccupations(nModes, nTransitions, ibi, iki, iSpin, dt, energyAvgWindow, totalDeltaNj, &
+    call realTimeIntegration(nModes, nTransitions, ibi, iki, iSpin, dt, energyAvgWindow, totalDeltaNj, &
           transitionRate, carrierDensityInput, energyTableDir, njNewOutDir, volumeLine, njBase)
 
 

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -117,26 +117,23 @@ program LSFmain
 
   if(ionode) write(*, '("Beginning transition-rate calculation")')
    
-
   call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, iSpin, mDim, nModes, order, dE, dtau, &
           gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
           captured, diffOmega, volumeLine, transitionRate)
 
-  
+  ! Only pass a slice over transitions  here because we know for scattering
+  ! there is no parallelization over k-points.
+  if(generateNewOccupations) &
+    call calcAndWriteNewOccupations(nModes, nTransitions, ibi, iki, iSpin, dt, energyAvgWindow, totalDeltaNj, &
+          transitionRate, carrierDensityInput, energyTableDir, njNewOutDir, volumeLine, njBase)
+
+
   deallocate(dE)
   deallocate(matrixElement)
   deallocate(omega)
   deallocate(omegaPrime)
   deallocate(Sj)
   deallocate(SjPrime)
-
-  ! Only pass a slice over transitions  here because we know for scattering
-  ! there is no parallelization over k-points.
-  if(generateNewOccupations) &
-    call calcAndWriteNewOccupations(nModes, nTransitions, ibi, iki, iSpin, dt, energyAvgWindow, totalDeltaNj, &
-          transitionRate, carrierDensityInput, energyTableDir, volumeLine, njBase)
-
-
   deallocate(ibi,ibf,iki,ikf)
   deallocate(transitionRate)
   deallocate(njBase)

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -31,7 +31,7 @@ program LSFmain
   call readInputParams(iSpin, nRealTimeSteps, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime_transRate, &
         SjThresh, smearingExpTolerance, addDeltaNj, captured, diffOmega, generateNewOccupations, newEnergyTable, &
         oldFormat, rereadDq, reSortMEs, carrierDensityInput, deltaNjBaseDir, dqInput, energyTableDir, &
-        matrixElementDir, MjBaseDir, njBaseInput, njNewOutDir, optimalPairsInput, outputDir, prefix, SjBaseDir)
+        matrixElementDir, MjBaseDir, njBaseInput, njNewOutDir, optimalPairsInput, prefix, SjBaseDir, transRateOutDir)
 
 
   nStepsLocal_transRate = ceiling((maxTime_transRate/dtau)/nProcPerPool)
@@ -121,7 +121,7 @@ program LSFmain
    
   call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, iSpin, mDim, nModes, order, dE, dtau, &
           gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
-          captured, diffOmega, volumeLine, transitionRate)
+          captured, diffOmega, transRateOutDir, volumeLine, transitionRate)
 
   ! Only pass a slice over transitions  here because we know for scattering
   ! there is no parallelization over k-points.
@@ -129,7 +129,7 @@ program LSFmain
     call realTimeIntegration(mDim, nModes, nRealTimeSteps, nTransitions, order, ibi, ibf, iki, ikf, iSpin, &
             dE, dt, dtau, energyAvgWindow, gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, &
             SjThresh, totalDeltaNj, transitionRate, addDeltaNj, captured, diffOmega, carrierDensityInput, energyTableDir, &
-            njNewOutDir, volumeLine)
+            njNewOutDir, transRateOutDir, volumeLine)
 
 
   deallocate(dE)

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -119,9 +119,11 @@ program LSFmain
 
   allocate(transitionRate(nTransitions,nkPerPool))
    
-  call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, iSpin, mDim, nModes, order, dE, dtau, &
+  call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, 1, iSpin, mDim, nModes, order, dE, dtau, &
           gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
-          captured, diffOmega, transRateOutDir, volumeLine, transitionRate)
+          captured, diffOmega, generateNewOccupations, transRateOutDir, volumeLine, transitionRate)
+        ! Pass 1 in explicitly for iRt (the real-time step index). It will be ignored if
+        ! note generating new occupations. It only affects the transition rate file name.
 
   ! Only pass a slice over transitions  here because we know for scattering
   ! there is no parallelization over k-points.

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -77,9 +77,9 @@ program LSFmain
   allocate(njBase(nModes))
 
   if(addDeltaNj) then
-    allocate(njPlusDelta(nModes,nTransitions))
+    allocate(deltaNjInitApproach(nModes,nTransitions))
   else
-    allocate(njPlusDelta(1,1))
+    allocate(deltaNjInitApproach(1,1))
   endif
 
   if(generateNewOccupations) then
@@ -89,7 +89,7 @@ program LSFmain
   endif
 
   call readNj(ibi, ibf, iki, ikf, nModes, nTransitions, addDeltaNj, generateNewOccupations, deltaNjBaseDir, njBaseInput, &
-          njBase, njPlusDelta, totalDeltaNj)
+          deltaNjInitApproach, njBase, totalDeltaNj)
 
 
   allocate(jReSort(nModes))
@@ -119,8 +119,8 @@ program LSFmain
 
   allocate(transitionRate(nTransitions,nkPerPool))
    
-  call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, 1, iSpin, mDim, nModes, order, dE, dtau, &
-          gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
+  call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, 1, iSpin, mDim, nModes, order, dE, deltaNjInitApproach, &
+          dtau, gamma0, matrixElement, njBase, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
           captured, diffOmega, generateNewOccupations, transRateOutDir, volumeLine, transitionRate)
         ! Pass 1 in explicitly for iRt (the real-time step index). It will be ignored if
         ! note generating new occupations. It only affects the transition rate file name.
@@ -129,7 +129,7 @@ program LSFmain
   ! there is no parallelization over k-points.
   if(generateNewOccupations) &
     call realTimeIntegration(mDim, nModes, nRealTimeSteps, nTransitions, order, ibi, ibf, iki, ikf, iSpin, &
-            dE, dt, dtau, energyAvgWindow, gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, &
+            dE, deltaNjInitApproach, dt, dtau, energyAvgWindow, gamma0, matrixElement, njBase, omega, omegaPrime, Sj, SjPrime, &
             SjThresh, totalDeltaNj, transitionRate, addDeltaNj, captured, diffOmega, carrierDensityInput, energyTableDir, &
             njNewOutDir, transRateOutDir, volumeLine)
 
@@ -143,6 +143,7 @@ program LSFmain
   deallocate(ibi,ibf,iki,ikf)
   deallocate(transitionRate)
   deallocate(njBase)
+  deallocate(deltaNjInitApproach)
 
 
   call MPI_Barrier(worldComm, ierr)

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -116,6 +116,8 @@ program LSFmain
   call cpu_time(timer1)
 
   if(ionode) write(*, '("Beginning transition-rate calculation")')
+
+  allocate(transitionRate(nTransitions,nkPerPool))
    
   call getAndWriteTransitionRate(nTransitions, ibi, ibf, iki, ikf, iSpin, mDim, nModes, order, dE, dtau, &
           gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, SjThresh, addDeltaNj, &
@@ -124,8 +126,10 @@ program LSFmain
   ! Only pass a slice over transitions  here because we know for scattering
   ! there is no parallelization over k-points.
   if(generateNewOccupations) &
-    call realTimeIntegration(nModes, nTransitions, ibi, iki, iSpin, dt, energyAvgWindow, totalDeltaNj, &
-          transitionRate, carrierDensityInput, energyTableDir, njNewOutDir, volumeLine, njBase)
+    call realTimeIntegration(mDim, nModes, nRealTimeSteps, nTransitions, order, ibi, ibf, iki, ikf, iSpin, &
+            dE, dt, dtau, energyAvgWindow, gamma0, matrixElement, njBase, njPlusDelta, omega, omegaPrime, Sj, SjPrime, &
+            SjThresh, totalDeltaNj, transitionRate, addDeltaNj, captured, diffOmega, carrierDensityInput, energyTableDir, &
+            njNewOutDir, volumeLine)
 
 
   deallocate(dE)

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -31,7 +31,7 @@ program LSFmain
   call readInputParams(iSpin, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime, SjThresh, &
         smearingExpTolerance, addDeltaNj, captured, diffOmega, generateNewOccupations, newEnergyTable, &
         oldFormat, rereadDq, reSortMEs, carrierDensityInput, deltaNjBaseDir, dqInput, energyTableDir, &
-        matrixElementDir, MjBaseDir, njBaseInput, optimalPairsInput, outputDir, prefix, SjBaseDir)
+        matrixElementDir, MjBaseDir, njBaseInput, njNewOutDir, optimalPairsInput, outputDir, prefix, SjBaseDir)
 
 
   nStepsLocal = ceiling((maxTime/dtau)/nProcPerPool)

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -28,15 +28,15 @@ program LSFmain
   if(ionode) write(*, '("Getting input parameters and reading necessary input files.")')
   call cpu_time(timer1)
 
-  call readInputParams(iSpin, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime, SjThresh, &
+  call readInputParams(iSpin, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime_transRate, SjThresh, &
         smearingExpTolerance, addDeltaNj, captured, diffOmega, generateNewOccupations, newEnergyTable, &
         oldFormat, rereadDq, reSortMEs, carrierDensityInput, deltaNjBaseDir, dqInput, energyTableDir, &
         matrixElementDir, MjBaseDir, njBaseInput, njNewOutDir, optimalPairsInput, outputDir, prefix, SjBaseDir)
 
 
-  nStepsLocal = ceiling((maxTime/dtau)/nProcPerPool)
+  nStepsLocal_transRate = ceiling((maxTime_transRate/dtau)/nProcPerPool)
     ! Would normally calculate the total number of steps as
-    !         nSteps = ceiling(maxTime/dtau)
+    !         nSteps = ceiling(maxTime_transRate/dtau)
     ! then divide the steps across all of the processes in 
     ! the pool. However, the number of steps could be a very 
     ! large integer that could cause overflow. Instead, directly
@@ -48,17 +48,17 @@ program LSFmain
     ! this way will overestimate the number of steps
     ! needed, but that is okay.
 
-  if(nStepsLocal < 0) call exitError('LSF main', 'integer overflow', 1)
+  if(nStepsLocal_transRate < 0) call exitError('LSF main', 'integer overflow', 1)
     ! If there is integer overflow, the number will go to the
     ! most negative integer value available
 
 
-  if(mod(nStepsLocal,2) == 0) nStepsLocal = nStepsLocal + 1
+  if(mod(nStepsLocal_transRate,2) == 0) nStepsLocal_transRate = nStepsLocal_transRate + 1
     ! Simpson's method requires the number of integration
     ! steps to be odd because a 3-point quadratic
     ! interpolation is used
    
-  if(ionode) write(*,'("  Each process is completing ", i15, " time steps.")') nStepsLocal
+  if(ionode) write(*,'("  Each process is completing ", i15, " time steps for the transition-rate integration.")') nStepsLocal_transRate
 
 
   ! Distribute k-points in pools (k-point parallelization only currently

--- a/LSF/src/LSF_main.f90
+++ b/LSF/src/LSF_main.f90
@@ -28,8 +28,8 @@ program LSFmain
   if(ionode) write(*, '("Getting input parameters and reading necessary input files.")')
   call cpu_time(timer1)
 
-  call readInputParams(iSpin, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime_transRate, SjThresh, &
-        smearingExpTolerance, addDeltaNj, captured, diffOmega, generateNewOccupations, newEnergyTable, &
+  call readInputParams(iSpin, nRealTimeSteps, order, dt, dtau, energyAvgWindow, gamma0, hbarGamma, maxTime_transRate, &
+        SjThresh, smearingExpTolerance, addDeltaNj, captured, diffOmega, generateNewOccupations, newEnergyTable, &
         oldFormat, rereadDq, reSortMEs, carrierDensityInput, deltaNjBaseDir, dqInput, energyTableDir, &
         matrixElementDir, MjBaseDir, njBaseInput, njNewOutDir, optimalPairsInput, outputDir, prefix, SjBaseDir)
 

--- a/LSF/src/LSF_module.f90
+++ b/LSF/src/LSF_module.f90
@@ -2032,7 +2032,7 @@ contains
 
       if(ionode) write(*, '("Writing occupations for time-integration step ",i5)') iRt
 
-      call writeNewOccupations(nModes, njBase, njRateOfChange, dt, njNewOutDir)
+      call writeNewOccupations(iRt, nModes, njBase, njRateOfChange, dt, njNewOutDir)
 
     enddo
 
@@ -2412,11 +2412,13 @@ contains
   end subroutine integrateOverInitialStates
   
 !----------------------------------------------------------------------------
-  subroutine writeNewOccupations(nModes, njBase, njRateOfChange, dt, njNewOutDir)
+  subroutine writeNewOccupations(iRt, nModes, njBase, njRateOfChange, dt, njNewOutDir)
 
     implicit none
 
     ! Input variables:
+    integer, intent(in) :: iRt
+      !! Real-time integration step index
     integer, intent(in) :: nModes
       !! Number of phonon modes
 
@@ -2437,7 +2439,7 @@ contains
       !! Loop index
 
     if(ionode) then
-      open(unit=37, file=trim(njNewOutDir)//'/nj.new.out')
+      open(unit=37, file=trim(njNewOutDir)//'/nj.'//trim(int2str(iRt))//'.out')
       write(37,'("# dt = ",ES24.15E3)') dt
       write(37,'("# j, New nj, Rate of change (1/s)")')
 

--- a/LSF/src/LSF_module.f90
+++ b/LSF/src/LSF_module.f90
@@ -2011,6 +2011,117 @@ contains
   end subroutine getUniqueInitialStates
 
 !----------------------------------------------------------------------------
+  subroutine readCarrierDensity(nUniqueInitStates, dEEigInit, energyAvgWindow, carrierDensityInput, volumeLine, carrierDensity)
+
+    use cell, only: volume
+
+    implicit none
+
+    ! Input variables:
+    integer, intent(in) :: nUniqueInitStates
+      !! Number of unique initial states, defined by
+      !! iki and ibi pairs
+
+    real(kind=dp), intent(in) :: dEEigInit(nUniqueInitStates)
+      !! Eigenvalue difference of initial states
+      !! relative to band edge
+    real(kind=dp), intent(in) :: energyAvgWindow
+      !! Size of window to average over for carrier 
+      !! density evaluation
+
+    character(len=300), intent(in) :: carrierDensityInput
+      !! Path to carrier density if generating 
+      !! new phonon occupations
+    character(len=300), intent(in) :: volumeLine
+      !! Volume line from overlap file to be
+      !! output exactly in transition rate file
+
+    ! Output variables:
+    real(kind=dp), intent(out) :: carrierDensity(nUniqueInitStates)
+      !! Carrier density for each of the initial states, averaged
+      !! over a given window
+
+    ! Local variables:
+    integer :: iS, iUInit
+      !! Loop index
+    integer :: nSamplesEachInitState(nUniqueInitStates)
+      !! Number of energy samples within the averaging window
+      !! for each initial state
+    integer :: nSampleEnergies
+      !! Number of energy samples in carrier density file
+
+    real(kind=dp) :: carrierDensity_iS
+      !! Carrier density of this energy sample
+    real(kind=dp) :: dEEigInit_iS
+      !! Eigenvalue difference of this energy sample
+      !! relative to band edge
+    real(kind=dp) :: rDum
+      !! Dummy real to ignore input
+
+    character(len=300) :: textDum
+      !! Dummy text to ignore input
+
+
+    if(ionode) then
+      open(unit=37, file=trim(carrierDensityInput))
+
+      ! Ignore 3 header lines
+      read(37,*)
+      read(37,*)
+      read(37,*)
+
+      ! Read in the number of points in the carrier density file
+      read(37,*) nSampleEnergies
+
+      ! Ignore final header line
+      read(37,*)
+
+
+      ! Initialize the carrier density for each initial state to zero
+      carrierDensity = 0.0_dp
+      nSamplesEachInitState = 0
+
+      ! Note that the arrays in our system are index in order of increasing
+      ! energy (i.e., band index), but the carrier-density file is in order
+      ! of increasing energy from the band edge, so for holes they will be
+      ! in the opposite order.
+      do iS = 1, nSampleEnergies
+        read(37,*) dEEigInit_iS, rDum, carrierDensity_iS
+
+        do iUInit = 1, nUniqueInitStates
+          ! Have to use the negative sign because energies are positive in carrier
+          ! density file
+          if(abs(-dEEigInit_iS - dEEigInit(iUInit)) <= energyAvgWindow/2.0_dp) then
+            nSamplesEachInitState(iUInit) = nSamplesEachInitState(iUInit) + 1
+            carrierDensity(iUInit) = carrierDensity(iUInit) + carrierDensity_iS
+          endif
+
+          ! Use this to investigate your energyAvgWindow
+          !write(*,'(2i5,4ES12.3E3, L5, i5, ES12.3E3)') iS, iUInit, -dEEigInit_iS, dEEigInit(iUInit), &
+          !                           abs(-dEEigInit_iS - dEEigInit(iUInit)), energyAvgWindow, &
+          !                           abs(-dEEigInit_iS - dEEigInit(iUInit)) <= energyAvgWindow/2.0_dp, &
+          !                           nSamplesEachInitState(iUInit), carrierDensity(iUInit) 
+
+        enddo
+
+      enddo
+
+      close(37)
+
+
+      read(volumeLine,'(a51, ES24.15E3)') textDum, volume
+
+      where(nSamplesEachInitState /= 0) carrierDensity = carrierDensity/nSamplesEachInitState*volume*(BohrToMeter*1.0d2)**3
+
+    endif
+
+    call MPI_BCAST(carrierDensity, nUniqueInitStates, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+
+    return
+
+  end subroutine readCarrierDensity
+
+!----------------------------------------------------------------------------
   subroutine getOccRateOfChange(nModes, nTransitions, ibi, iki, nUniqueInitStates, uniqueInitStates_ib, &
           uniqueInitStates_ik, carrierDensity, dEEigInit, dt, totalDeltaNj, transitionRate, njBase, njRateOfChange)
 
@@ -2131,117 +2242,6 @@ contains
     return
 
   end subroutine sumOverFinalStates
-
-!----------------------------------------------------------------------------
-  subroutine readCarrierDensity(nUniqueInitStates, dEEigInit, energyAvgWindow, carrierDensityInput, volumeLine, carrierDensity)
-
-    use cell, only: volume
-
-    implicit none
-
-    ! Input variables:
-    integer, intent(in) :: nUniqueInitStates
-      !! Number of unique initial states, defined by
-      !! iki and ibi pairs
-
-    real(kind=dp), intent(in) :: dEEigInit(nUniqueInitStates)
-      !! Eigenvalue difference of initial states
-      !! relative to band edge
-    real(kind=dp), intent(in) :: energyAvgWindow
-      !! Size of window to average over for carrier 
-      !! density evaluation
-
-    character(len=300), intent(in) :: carrierDensityInput
-      !! Path to carrier density if generating 
-      !! new phonon occupations
-    character(len=300), intent(in) :: volumeLine
-      !! Volume line from overlap file to be
-      !! output exactly in transition rate file
-
-    ! Output variables:
-    real(kind=dp), intent(out) :: carrierDensity(nUniqueInitStates)
-      !! Carrier density for each of the initial states, averaged
-      !! over a given window
-
-    ! Local variables:
-    integer :: iS, iUInit
-      !! Loop index
-    integer :: nSamplesEachInitState(nUniqueInitStates)
-      !! Number of energy samples within the averaging window
-      !! for each initial state
-    integer :: nSampleEnergies
-      !! Number of energy samples in carrier density file
-
-    real(kind=dp) :: carrierDensity_iS
-      !! Carrier density of this energy sample
-    real(kind=dp) :: dEEigInit_iS
-      !! Eigenvalue difference of this energy sample
-      !! relative to band edge
-    real(kind=dp) :: rDum
-      !! Dummy real to ignore input
-
-    character(len=300) :: textDum
-      !! Dummy text to ignore input
-
-
-    if(ionode) then
-      open(unit=37, file=trim(carrierDensityInput))
-
-      ! Ignore 3 header lines
-      read(37,*)
-      read(37,*)
-      read(37,*)
-
-      ! Read in the number of points in the carrier density file
-      read(37,*) nSampleEnergies
-
-      ! Ignore final header line
-      read(37,*)
-
-
-      ! Initialize the carrier density for each initial state to zero
-      carrierDensity = 0.0_dp
-      nSamplesEachInitState = 0
-
-      ! Note that the arrays in our system are index in order of increasing
-      ! energy (i.e., band index), but the carrier-density file is in order
-      ! of increasing energy from the band edge, so for holes they will be
-      ! in the opposite order.
-      do iS = 1, nSampleEnergies
-        read(37,*) dEEigInit_iS, rDum, carrierDensity_iS
-
-        do iUInit = 1, nUniqueInitStates
-          ! Have to use the negative sign because energies are positive in carrier
-          ! density file
-          if(abs(-dEEigInit_iS - dEEigInit(iUInit)) <= energyAvgWindow/2.0_dp) then
-            nSamplesEachInitState(iUInit) = nSamplesEachInitState(iUInit) + 1
-            carrierDensity(iUInit) = carrierDensity(iUInit) + carrierDensity_iS
-          endif
-
-          ! Use this to investigate your energyAvgWindow
-          !write(*,'(2i5,4ES12.3E3, L5, i5, ES12.3E3)') iS, iUInit, -dEEigInit_iS, dEEigInit(iUInit), &
-          !                           abs(-dEEigInit_iS - dEEigInit(iUInit)), energyAvgWindow, &
-          !                           abs(-dEEigInit_iS - dEEigInit(iUInit)) <= energyAvgWindow/2.0_dp, &
-          !                           nSamplesEachInitState(iUInit), carrierDensity(iUInit) 
-
-        enddo
-
-      enddo
-
-      close(37)
-
-
-      read(volumeLine,'(a51, ES24.15E3)') textDum, volume
-
-      where(nSamplesEachInitState /= 0) carrierDensity = carrierDensity/nSamplesEachInitState*volume*(BohrToMeter*1.0d2)**3
-
-    endif
-
-    call MPI_BCAST(carrierDensity, nUniqueInitStates, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-
-    return
-
-  end subroutine readCarrierDensity
 
 !----------------------------------------------------------------------------
   subroutine integrateOverInitialStates(nModes, nUniqueInitStates, carrierDensity, dEEigInit, dt, &

--- a/PhononPP/src/PhononPP_module.f90
+++ b/PhononPP/src/PhononPP_module.f90
@@ -2058,7 +2058,7 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine readNj(ibi, ibf, iki, ikf, nModes, nTransitions, addDeltaNj, generateNewOccupations, deltaNjBaseDir, njBaseInput, &
-          njBase, njPlusDelta, totalDeltaNj)
+          deltaNjInitApproach, njBase, totalDeltaNj)
 
     implicit none
 
@@ -2082,11 +2082,11 @@ module PhononPPMod
       !! Path to nj file
 
     ! Output variables:
+    real(kind=dp), intent(out) :: deltaNjInitApproach(:,:)
+      !! Optional delta nj from adjustment to 
+      !! carrier approach in initial state
     real(kind=dp), intent(out) :: njBase(nModes)
       !! \(n_j\) occupation number
-    real(kind=dp), intent(out) :: njPlusDelta(:,:)
-      !! Optional nj plus delta nj from adjustment to 
-      !! carrier approach in initial state
     real(kind=dp), intent(out) :: totalDeltaNj(:,:)
       !! Optional total change in occupation numbers
       !! for each mode and transition
@@ -2151,7 +2151,7 @@ module PhononPPMod
           do j = 1, nModes
             read(64,'(i7,3ES24.15E3)') iDum, deltaNj_gi, deltaNj_if, deltaNj_fg
 
-            if(addDeltaNj) njPlusDelta(j,iE) = njBase(j) + deltaNj_gi
+            if(addDeltaNj) deltaNjInitApproach(j,iE) = deltaNj_gi
             if(generateNewOccupations) totalDeltaNj(j,iE) = deltaNj_gi + deltaNj_if + deltaNj_fg
           enddo
 
@@ -2162,7 +2162,7 @@ module PhononPPMod
     endif ! End if ionode
 
     call MPI_BCAST(njBase, size(njBase), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
-    call MPI_BCAST(njPlusDelta, size(njPlusDelta), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
+    call MPI_BCAST(deltaNjInitApproach, size(deltaNjInitApproach), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
     call MPI_BCAST(totalDeltaNj, size(totalDeltaNj), MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
     return


### PR DESCRIPTION
For H release, we need to update the occupations based on the transition rates and carrier densities, then use the updated occupations in new calculations to iterate forward in time. In this change, I added a loop to perform these calculations and implemented RK4 integration for improved stability and better convergence.