### PR TITLE
Implement optimal band matching

### DIFF
--- a/CommonModules/Makefile
+++ b/CommonModules/Makefile
@@ -5,7 +5,7 @@ include ../make.sys
 #location of needed modules
 MODFLAGS = -I.
 
-MODULES = constants.o miscUtilities.o readInputFiles.o generalComputations.o errorsAndMPI.o cell.o base.o hungarian.o
+MODULES = constants.o miscUtilities.o readInputFiles.o generalComputations.o errorsAndMPI.o cell.o base.o hungarian.o optimalBandMatching.o
 DEBUGFLAGS = -check all -g -warn all -traceback -gen-interfaces 
 
 all : commonmodules.a

--- a/CommonModules/optimalBandMatching.f90
+++ b/CommonModules/optimalBandMatching.f90
@@ -1,0 +1,171 @@
+module optimalBandMatching
+  
+  use miscUtilities, only: int2str
+  use constants
+  use errorsAndMPI
+  use mpi
+  
+  implicit none
+  
+  contains
+
+!----------------------------------------------------------------------------
+  subroutine findOptimalPairsAndOutput(iBandLBra, iBandHBra, iBandLKet, iBandHKet, ikLocal, isp, nPairs, Ufi, optimalPairsDir)
+
+    use hungarianOptimizationMod, only: hungarianOptimalMatching
+
+    implicit none
+
+    ! Input variables:
+    integer, intent(in) :: iBandLBra, iBandHBra, iBandLKet, iBandHKet
+      !! Optional band bounds
+    integer, intent(in) :: ikLocal
+      !! Current local k-point
+    integer, intent(in) :: isp
+      !! Current spin channel
+    integer, intent(in) :: nPairs
+      !! Number of pairs of bands to get overlaps for
+
+    complex(kind=dp), intent(in) :: Ufi(nPairs)
+      !! All-electron overlap
+
+    character(len=300), intent(in) :: optimalPairsDir
+      !! Path to store or read optimalPairs.out file
+
+    ! Local variables:
+    integer :: ikGlobal
+      !! Current global k-point
+    integer :: ip, ibB, ibK
+      !! Loop indices
+    integer, allocatable :: maxBandPair(:)
+      !! Optimal band pair to maximize overlaps
+    integer :: nBandsEachSys
+      !! Number of bands per system (bra/ket) to line up
+
+    real(kind=dp), allocatable :: norm2Ufi2D(:,:)
+      !! 2D version of overlap array (needed for passing
+      !! into optimization subroutine)
+    real(kind=dp) :: t1, t2
+
+
+    nBandsEachSys = (iBandHBra - iBandLBra + 1)
+      ! Doesn't matter which system you use here because we already
+      ! confirmed that they have the same number
+
+    allocate(norm2Ufi2D(nBandsEachSys,nBandsEachSys))
+
+    ip = 0
+    do ibB = 1, nBandsEachSys
+      do ibK = 1, nBandsEachSys
+        ip = ip + 1
+        norm2Ufi2D(ibB,ibK) = abs(Ufi(ip))**2
+      enddo
+    enddo
+
+
+    allocate(maxBandPair(nBandsEachSys))
+
+    if(ionode) write(*,'("  Beginning optimal matching algorithm to match ",i7," sets of bands.")') nBandsEachSys
+    call cpu_time(t1)
+
+    call hungarianOptimalMatching(nBandsEachSys, norm2Ufi2D, .false., maxBandPair)
+
+    call cpu_time(t2)
+    if(ionode) write(*,'("  Optimal matching complete! (",f10.2," secs)")') t2-t1
+
+
+    ikGlobal = ikLocal+ikStart_pool-1
+
+    open(64,file=trim(optimalPairsDir)//'/optimalPairs.'//trim(int2str(isp))//'.'//trim(int2str(ikGlobal))//'.out')
+
+    write(64,'("# Number of bands in each system, iBandLBra, iBandHBra, iBandLKet, iBandHKet")')
+    write(64,'(5i10)') nBandsEachSys, iBandLBra, iBandHBra, iBandLKet, iBandHKet
+
+    write(64,'("# ibBra, ibKet, Overlap")')
+
+    do ibK = 1, nBandsEachSys ! Loop over second (col) index
+      write(64,'(2i10,ES13.4E3)') maxBandPair(ibK)+iBandLBra-1, ibK+iBandLKet-1, norm2Ufi2D(maxBandPair(ibK),ibK) 
+    enddo
+
+    close(64)
+
+    return
+
+  end subroutine findOptimalPairsAndOutput
+
+!----------------------------------------------------------------------------
+  subroutine readAllOptimalPairs(ikGlobal, nSpins, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
+        ibBra_optimal)
+    ! The optimal pairs file contains the best match between the bra-system (defect)
+    ! and ket-system (perfect crystal) state indices. Because we take the energies 
+    ! from the perfect-crystal system, I do not rearrange those states. Instead, 
+    ! I find the corresponding match from the defect system. 
+    !
+    ! This file can be confusing because the indices come from the defect system, 
+    ! but the perfect-crystal-system states are not shifted while those from the
+    ! defect system are. I tried to think of a way around this, but using the defect
+    ! indices just makes sense so that all of the codes can work consistently with
+    ! the zeroth- and first-order term, with the latter containing only defect states.
+
+    implicit none
+
+    ! Input variables:
+    integer, intent(in) :: ikGlobal
+      !! Current global k-point
+    integer, intent(in) :: nSpins
+      !! Number of spins (tested to be consistent
+      !! across all systems)
+
+    logical, intent(in) :: spin1Skipped, spin2Skipped
+      !! If spin channels skipped
+
+    character(len=300), intent(in) :: optimalPairsDir
+      !! Path to store or read optimalPairs.out file
+
+    ! Output variables:
+    integer, intent(out) :: iBandLKet, iBandHKet
+      !! Band bounds from optimalPairs file
+    integer, allocatable, intent(out) :: ibBra_optimal(:,:)
+      !! Optimal index from the bra system corresponding 
+      !! to the input index from the ket system
+
+    ! Local variables:
+    integer :: iBandLBra, iBandHBra
+      !! Band bounds from optimalPairs file
+    integer :: isp, ibp, ibKet, ibBra
+      !! Loop indices
+    integer :: nBandsEachSys
+      !! Number of bands per system (bra/ket) to line up
+
+
+    do isp = 1, nSpins
+      if((isp == 1 .and. .not. spin1Skipped) .or. (isp == 2 .and. .not. spin2Skipped)) then
+
+        open(64,file=trim(optimalPairsDir)//'/optimalPairs.'//trim(int2str(isp))//'.'//trim(int2str(ikGlobal))//'.out')
+
+        read(64,*)
+        read(64,'(5i10)') nBandsEachSys, iBandLBra, iBandHBra, iBandLKet, iBandHKet
+
+        if(isp == 1 .or. spin1Skipped) allocate(ibBra_optimal(nSpins,iBandLKet:iBandHKet))
+          ! Assume that the band bounds are the same for both spin channels, which
+          ! should currently be the case unless the user messes with the files
+
+
+        read(64,*)
+
+        do ibp = 1, nBandsEachSys
+          read(64,*) ibBra, ibKet
+          ibBra_optimal(isp,ibKet) = ibBra
+            ! Storing it like this means it will work even if the 
+            ! band pairs get reordered somehow
+        enddo
+
+        close(64)
+      endif
+    enddo
+
+    return
+
+  end subroutine readAllOptimalPairs
+
+end module optimalBandMatching

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -16,7 +16,7 @@ program energyTabulatorMain
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
         ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, &
         energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, &
-        singleStateExportDir, captured, elecCarrier, loopSpins)
+        optimalPairsDir, singleStateExportDir, captured, elecCarrier, loopSpins, readOptimalPairs)
 
 
   call getnSpinsAndnKPoints(exportDirEigs, nKPoints, nSpins)

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -33,7 +33,8 @@ program energyTabulatorMain
   else
     if(ionode) call calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
         ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
-        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirGroundRelax, singleStateExportDir)
+        readOptimalPairs, allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirGroundRelax, &
+        optimalPairsDir, singleStateExportDir)
   endif
 
 

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -14,9 +14,9 @@ program energyTabulatorMain
 
   ! Get inputs from user
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-        ispSelect, refBand, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir, &
-        exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, singleStateExportDir, captured, elecCarrier, &
-        loopSpins)
+        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
+        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, &
+        exportDirFinalFinal, singleStateExportDir, captured, elecCarrier, loopSpins)
 
 
   call getnSpinsAndnKPoints(exportDirEigs, nKPoints, nSpins)
@@ -32,8 +32,8 @@ program energyTabulatorMain
         eCorrectEigRef, elecCarrier, loopSpins, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal)
   else
     if(ionode) call calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
-        ikFinit, ikFfinal, ispSelect, nSpins, refBand, eCorrectEigRef, elecCarrier, loopSpins, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, singleStateExportDir)
+        ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
+        allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir, exportDirEigs, singleStateExportDir)
   endif
 
 

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -15,7 +15,7 @@ program energyTabulatorMain
   ! Get inputs from user
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
         ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, &
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, &
         exportDirFinalFinal, singleStateExportDir, captured, elecCarrier, loopSpins)
 
 
@@ -33,7 +33,7 @@ program energyTabulatorMain
   else
     if(ionode) call calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
         ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
-        allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir, exportDirEigs, singleStateExportDir)
+        allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, singleStateExportDir)
   endif
 
 

--- a/EnergyTabulator/src/EnergyTabulator_main.f90
+++ b/EnergyTabulator/src/EnergyTabulator_main.f90
@@ -14,9 +14,9 @@ program energyTabulatorMain
 
   ! Get inputs from user
   call readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, &
-        exportDirFinalFinal, singleStateExportDir, captured, elecCarrier, loopSpins)
+        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, &
+        energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, &
+        singleStateExportDir, captured, elecCarrier, loopSpins)
 
 
   call getnSpinsAndnKPoints(exportDirEigs, nKPoints, nSpins)
@@ -33,7 +33,7 @@ program energyTabulatorMain
   else
     if(ionode) call calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
         ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
-        allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, singleStateExportDir)
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirGroundRelax, singleStateExportDir)
   endif
 
 

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -33,8 +33,6 @@ module energyTabulatorMod
   real(kind=dp) :: eCorrectEigRef
     !! Correction to eigenvalue difference with reference carrier, if any
 
-  character(len=300) :: allStatesBaseDir_relaxed
-    !! Base dir for sets of relaxed files if not captured
   character(len=300) :: allStatesBaseDir_relaxPosGround
     !! Base dir for each of the different relaxed positions
     !! with ground-state configuration if not captured
@@ -51,6 +49,8 @@ module energyTabulatorMod
   character(len=300) :: exportDirFinalFinal
     !! Path to export for final charge state
     !! in the final positions
+  character(len=300) :: exportDirGroundRelax
+    !! Path to export for relaxed ground state
   character(len=300) :: singleStateExportDir
     !! Export dir name within each subfolder
 
@@ -64,8 +64,8 @@ module energyTabulatorMod
 
 !----------------------------------------------------------------------------
   subroutine readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, &
+        energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, &
         singleStateExportDir, captured, elecCarrier, loopSpins)
 
     implicit none
@@ -93,8 +93,6 @@ module energyTabulatorMod
     real(kind=dp), intent(out) :: eCorrectEigRef
       !! Correction to eigenvalue difference with reference carrier, if any
 
-    character(len=300), intent(out) :: allStatesBaseDir_relaxed
-      !! Base dir for sets of relaxed files if not captured
     character(len=300), intent(out) :: allStatesBaseDir_relaxPosGround
       !! Base dir for each of the different relaxed positions
       !! with ground-state configuration if not captured
@@ -111,6 +109,8 @@ module energyTabulatorMod
     character(len=300), intent(out) :: exportDirFinalFinal
       !! Path to export for final charge state
       !! in the final positions
+    character(len=300), intent(out) :: exportDirGroundRelax
+      !! Path to export for relaxed ground state
     character(len=300), intent(out) :: singleStateExportDir
       !! Export dir name within each subfolder
 
@@ -123,7 +123,7 @@ module energyTabulatorMod
       !! otherwise, use selected spin channel
   
     namelist /inputParams/ exportDirEigs, exportDirFinalFinal, exportDirFinalInit, exportDirInitInit, energyTableDir, &
-                           eCorrectTot, eCorrectEigRef, captured, elecCarrier, ispSelect, allStatesBaseDir_relaxed, singleStateExportDir, &
+                           eCorrectTot, eCorrectEigRef, captured, elecCarrier, ispSelect, exportDirGroundRelax, singleStateExportDir, &
                            iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, refBand, ikIinit, ikIfinal, ikFinit, ikFfinal, &
                            ibShift_eig, allStatesBaseDir_relaxPosGround, dENegThresh, dEZeroThresh
 
@@ -132,8 +132,8 @@ module energyTabulatorMod
 
       ! Set default values for input variables and start timers
       call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, ispSelect, &
-            refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, &
-            energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, singleStateExportDir, &
+            refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, energyTableDir, &
+            exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, singleStateExportDir, &
             captured, elecCarrier)
     
       ! Read input variables
@@ -143,8 +143,8 @@ module energyTabulatorMod
 
       ! Check that all variables were properly set
       call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-            ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-            allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+            ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, &
+            energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, &
             singleStateExportDir, captured, elecCarrier, loopSpins)
 
     endif
@@ -170,13 +170,13 @@ module energyTabulatorMod
     call MPI_BCAST(eCorrectTot, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
     call MPI_BCAST(eCorrectEigRef, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
-    call MPI_BCAST(allStatesBaseDir_relaxed, len(allStatesBaseDir_relaxed), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(allStatesBaseDir_relaxPosGround, len(allStatesBaseDir_relaxPosGround), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(energyTableDir, len(energyTableDir), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirEigs, len(exportDirEigs), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirInitInit, len(exportDirInitInit), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirFinalInit, len(exportDirFinalInit), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirFinalFinal, len(exportDirFinalFinal), MPI_CHARACTER, root, worldComm, ierr)
+    call MPI_BCAST(exportDirGroundRelax, len(exportDirGroundRelax), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(singleStateExportDir, len(singleStateExportDir), MPI_CHARACTER, root, worldComm, ierr)
 
     call MPI_BCAST(captured, 1, MPI_LOGICAL, root, worldComm, ierr)
@@ -188,8 +188,8 @@ module energyTabulatorMod
 
 !----------------------------------------------------------------------------
   subroutine initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, &
+        energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, &
         singleStateExportDir, captured, elecCarrier)
     !! Set the default values for input variables and start timer
     !!
@@ -226,8 +226,6 @@ module energyTabulatorMod
     real(kind=dp), intent(out) :: eCorrectEigRef
       !! Correction to eigenvalue difference with reference carrier, if any
 
-    character(len=300), intent(out) :: allStatesBaseDir_relaxed
-      !! Base dir for sets of relaxed files if not captured
     character(len=300), intent(out) :: allStatesBaseDir_relaxPosGround
       !! Base dir for each of the different relaxed positions
       !! with ground-state configuration if not captured
@@ -244,6 +242,8 @@ module energyTabulatorMod
     character(len=300), intent(out) :: exportDirFinalFinal
       !! Path to export for final charge state
       !! in the final positions
+    character(len=300), intent(out) :: exportDirGroundRelax
+      !! Path to export for relaxed ground state
     character(len=300), intent(out) :: singleStateExportDir
       !! Export dir name within each subfolder
 
@@ -271,13 +271,13 @@ module energyTabulatorMod
     eCorrectTot = 0.0_dp
     eCorrectEigRef = 0.0_dp
 
-    allStatesBaseDir_relaxed = ''
     allStatesBaseDir_relaxPosGround = ''
     energyTableDir = './'
     exportDirEigs = ''
     exportDirInitInit = ''
     exportDirFinalInit = ''
     exportDirFinalFinal = ''
+    exportDirGroundRelax = ''
     singleStateExportDir = ''
 
     captured = .true.
@@ -287,9 +287,9 @@ module energyTabulatorMod
 
 !----------------------------------------------------------------------------
   subroutine checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
-        singleStateExportDir, captured, elecCarrier, loopSpins)
+        ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxPosGround, energyTableDir, &
+        exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, exportDirGroundRelax, singleStateExportDir, &
+        captured, elecCarrier, loopSpins)
 
     implicit none
 
@@ -316,8 +316,6 @@ module energyTabulatorMod
     real(kind=dp), intent(inout) :: eCorrectEigRef
       !! Correction to eigenvalue difference with reference carrier, if any
 
-    character(len=300), intent(in) :: allStatesBaseDir_relaxed
-      !! Base dir for sets of relaxed files if not captured
     character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
       !! Base dir for each of the different relaxed positions
       !! with ground-state configuration if not captured
@@ -334,6 +332,8 @@ module energyTabulatorMod
     character(len=300), intent(in) :: exportDirFinalFinal
       !! Path to export for final charge state
       !! in the final positions
+    character(len=300), intent(in) :: exportDirGroundRelax
+      !! Path to export for relaxed ground state
     character(len=300), intent(in) :: singleStateExportDir
       !! Export dir name within each subfolder
 
@@ -392,7 +392,7 @@ module energyTabulatorMod
       abortExecution = checkIntInitialization('ikFinit', ikFinit, 1, int(1e9)) .or. abortExecution
       abortExecution = checkIntInitialization('ikFfinal', ikFfinal, ikFinit, int(1e9)) .or. abortExecution 
 
-      write(*,'("allStatesBaseDir_relaxed = ",a)') trim(allStatesBaseDir_relaxed)
+      write(*,'("exportDirGroundRelax = ",a)') trim(exportDirGroundRelax)
       write(*,'("allStatesBaseDir_relaxPosGround = ",a)') trim(allStatesBaseDir_relaxPosGround)
       write(*,'("singleStateExportDir = ",a)') trim(singleStateExportDir)
       write(*,'("dENegThresh = ", ES12.3E3, " (eV)")') dENegThresh
@@ -710,7 +710,7 @@ module energyTabulatorMod
 !----------------------------------------------------------------------------
   subroutine calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
         ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
-        allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, singleStateExportDir)
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirGroundRelax, singleStateExportDir)
 
     implicit none
 
@@ -743,8 +743,6 @@ module energyTabulatorMod
       !! Whether to loop over available spin channels;
       !! otherwise, use selected spin channel
 
-    character(len=300), intent(in) :: allStatesBaseDir_relaxed
-      !! Base dir for sets of relaxed files if not captured
     character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
       !! Base dir for each of the different relaxed positions
       !! with ground-state configuration if not captured
@@ -752,6 +750,8 @@ module energyTabulatorMod
       !! Path to energy tables
     character(len=300), intent(in) :: exportDirEigs
       !! Path to export for system to get eigenvalues
+    character(len=300), intent(in) :: exportDirGroundRelax
+      !! Path to export for relaxed ground state
     character(len=300), intent(in) :: singleStateExportDir
       !! Export dir name within each subfolder
 
@@ -774,13 +774,16 @@ module energyTabulatorMod
       !! Energy to be used in zeroth-order matrix element
     real(kind=dp), allocatable :: eigv(:,:)
       !! Eigenvalues
-    real(kind=dp), allocatable :: eTotRelax(:,:)
-      !! Total energies for all states in relaxed positions
-    real(kind=dp), allocatable :: eTotStartPos(:,:)
-      !! Total energies for all states in start positions
+    real(kind=dp) :: eTotGroundRelax
+      !! Total energy for relaxed ground-state system
+    real(kind=dp), allocatable :: eTotRelaxPos_ground(:,:)
+      !! Total energies for all relaxed positions but in
+      !! electronic ground state
     real(kind=dp) :: refEig
       !! Eigenvalue of WZP reference carrier
 
+    logical :: fileExists
+      !! If relaxed ground-state exported 'input' file exists
     logical :: inInitkRange, inFinalkRange
       !! If in k-point range
     logical, allocatable :: skipState(:,:)
@@ -798,8 +801,7 @@ module energyTabulatorMod
     ibMin = min(iBandIinit, iBandFinit)
     ibMax = max(iBandIfinal, iBandFfinal)
 
-    allocate(eTotRelax(ibMin:ibMax,ikMin:ikMax))
-    allocate(eTotStartPos(ibMin:ibMax,ikMin:ikMax))
+    allocate(eTotRelaxPos_ground(ibMin:ibMax,ikMin:ikMax))
     allocate(skipState(ibMin:ibMax,ikMin:ikMax))
     allocate(eigv(ibMin+ibShift_eig:ibMax+ibShift_eig,ikMin:ikMax))
       ! The bands in the eigenvalue system may not line up
@@ -807,9 +809,13 @@ module energyTabulatorMod
       ! so give the user the option to shift the bands so
       ! that they line up.
 
+    
+    call getTotalEnergy(exportDirGroundRelax, eTotGroundRelax, fileExists)
+    if(.not. fileExists) &
+      call exitError('calcAndWriteScatterEnergies','Input file does not exist in path '//trim(exportDirGroundRelax),1)
+
     call searchForStatesAndGetEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikIinit, ikIfinal, ikFInit, ikFfinal, &
-            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelax, &
-            eTotStartPos, skipState)
+            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelaxPos_ground, skipState)
 
 
     do isp = 1, nSpins
@@ -875,7 +881,7 @@ module energyTabulatorMod
                 ! The order of the total energy difference is the same for both cases because we
                 ! use total energy differences labeled by each state, rather than eigenvalue
                 ! differences.
-                dEDelta = eTotRelax(ibf,ikf) - eTotRelax(ibi,iki)
+                dEDelta = eTotRelaxPos_ground(ibf,ikf) - eTotRelaxPos_ground(ibi,iki)
 
                 if(dEDelta >= dENegThresh) then
                   ! If not allowing negative energy transfer to phonons (i.e., vibrational cooling),
@@ -933,8 +939,8 @@ module energyTabulatorMod
 
 
                 write(17,'(4i7,5ES24.15E3)') iki, ibi, ikf, ibf, dEDelta, dEZeroth, dEFirst, &
-                                             eTotStartPos(ibi,iki)-eTotRelax(ibi,iki), &
-                                             eTotRelax(ibf,ikf)-eTotStartPos(ibf,ikf)
+                                             eTotRelaxPos_ground(ibi,iki)-eTotGroundRelax, &
+                                             eTotGroundRelax-eTotRelaxPos_ground(ibf,ikf)
         
               enddo ! Loop over final bands 
             enddo ! Loop over final k-points
@@ -979,8 +985,7 @@ module energyTabulatorMod
 
 !----------------------------------------------------------------------------
   subroutine searchForStatesAndGetEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikIinit, ikIfinal, ikFInit, ikFfinal, &
-            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelax, &
-            eTotStartPos, skipState)
+            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelaxPos_ground, skipState)
     ! This subroutine searches for energy files for all states 
     ! within the given bounds. If the Export files are found, read
     ! the energies. If not, set the state to be skipped. 
@@ -996,8 +1001,6 @@ module energyTabulatorMod
       !! Overall bounds on k-points and bands for initial 
       !! and final states
 
-    character(len=300), intent(in) :: allStatesBaseDir_relaxed
-      !! Base dir for sets of relaxed files if not captured
     character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
       !! Base dir for each of the different relaxed positions
       !! with ground-state configuration if not captured
@@ -1005,10 +1008,9 @@ module energyTabulatorMod
       !! Export dir name within each subfolder
 
     ! Output variables:
-    real(kind=dp), intent(out) :: eTotRelax(ibMin:ibMax,ikMin:ikMax)
-      !! Total energies for all states in relaxed positions
-    real(kind=dp), intent(out) :: eTotStartPos(ibMin:ibMax,ikMin:ikMax)
-      !! Total energies for all states in start positions
+    real(kind=dp), intent(out) :: eTotRelaxPos_ground(ibMin:ibMax,ikMin:ikMax)
+      !! Total energies for all relaxed positions but in
+      !! electronic ground state
 
     logical, intent(out) :: skipState(ibMin:ibMax,ikMin:ikMax)
       !! If a state should be skipped
@@ -1027,8 +1029,7 @@ module energyTabulatorMod
 
 
     ! Get total energies from exports of all different structures
-    eTotRelax = 0.0_dp
-    eTotStartPos = 0.0_dp
+    eTotRelaxPos_ground = 0.0_dp
     skipState = .true.
     do ik = ikMin, ikMax
 
@@ -1046,30 +1047,18 @@ module energyTabulatorMod
           ! Only consider if band and k bounds line up for initial/final states
           if((inInitkRange .and. inInitBandRange) .or. (inFinalkRange .and. inFinalBandRange)) then
 
-            ! Get relaxed total energy for each state
-            ! Assume subfolders have pattern <allStatesBaseDir_relaxed>/k<ik>_b<ib>/<singleStateExportDir>
+            ! Get total energy for each set of relaxed positions with the ground-state
+            ! electronic configuration
+            ! Assume subfolders have pattern <allStatesBaseDir_relaxPosGround>/k<ik>_b<ib>/<singleStateExportDir>
             ! e.g., ../VASP/k1_b1616/export/
-            path = trim(allStatesBaseDir_relaxed)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/'//trim(singleStateExportDir)
-            call getTotalEnergy(path, eTotRelax(ib,ik), fileExists)
+            path = trim(allStatesBaseDir_relaxPosGround)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/'//trim(singleStateExportDir)
+            call getTotalEnergy(path, eTotRelaxPos_ground(ib,ik), fileExists)
 
-            ! Skip the consideration of this state if the necessary file
-            ! doesn't exist. Otherwise, track the minimum total energy to 
-            ! be output.
+            ! Skip the consideration of this state if the necessary file doesn't exist.
             if(fileExists) then
-
-              ! Get total energy for each state in start positions 
-              ! (e.g., ground-state positions)
-              path = trim(allStatesBaseDir_relaxPosGround)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/'//trim(singleStateExportDir)
-              call getTotalEnergy(path, eTotStartPos(ib,ik), fileExists)
-
-              ! If both files exist, mark this state to not be skipped
-              if(fileExists) then
-                skipState(ib,ik) = .false.
-              else
-                write(*,'("Skipping state ik,ib = ",2i7,"! Start-pos. input file does not exist in path ",a)') ik, ib, trim(path)
-              endif
+              skipState(ib,ik) = .false.
             else
-              write(*,'("Skipping state ik,ib = ",2i7,"! Relaxed input file does not exist in path ",a)') ik, ib, trim(path)
+              write(*,'("Skipping state ik,ib = ",2i7,"! Relax-pos., ground-state input file does not exist in path ",a)') ik, ib, trim(path)
             endif
 
           endif

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -907,6 +907,14 @@ module energyTabulatorMod
 
                 iE = iE + 1
 
+                ! Because we use eigenvalues here, we must switch the order for different carriers
+                ! since it is assumed that the user will index the states based on the type of carrier.
+                if(elecCarrier) then
+                  dEEigElectron = eigv(ibf+ibShift_eig,ikf) - eigv(ibi+ibShift_eig,iki)
+                else
+                  dEEigElectron = eigv(ibi+ibShift_eig,iki) - eigv(ibf+ibShift_eig,ikf)
+                endif
+
     
                 ! For scattering, we do separate calculations for each band state, so we only need
                 ! to use the total energy difference
@@ -914,7 +922,7 @@ module energyTabulatorMod
                 ! The order of the total energy difference is the same for both cases because we
                 ! use total energy differences labeled by each state, rather than eigenvalue
                 ! differences.
-                dEDelta = eTotRelaxPos_ground(isp,ibf,ikf) - eTotRelaxPos_ground(isp,ibi,iki)
+                dEDelta = eTotRelaxPos_ground(isp,ibf,ikf) - eTotRelaxPos_ground(isp,ibi,iki) + dEEigElectron
 
                 if(dEDelta >= dENegThresh) then
                   ! If not allowing negative energy transfer to phonons (i.e., vibrational cooling),
@@ -938,14 +946,6 @@ module energyTabulatorMod
                 ! The zeroth-order matrix element contains the electronic-only energy difference.
                 ! For scattering, this is just an eigenvalue difference. The eigenvalues must be
                 ! read from the same system to make the difference meaningful. 
-                ! Because we use eigenvalues here, we must switch the order for different carriers
-                ! since it is assumed that the user will index the states based on the type of carrier.
-                if(elecCarrier) then
-                  dEEigElectron = eigv(ibf+ibShift_eig,ikf) - eigv(ibi+ibShift_eig,iki)
-                else
-                  dEEigElectron = eigv(ibi+ibShift_eig,iki) - eigv(ibf+ibShift_eig,ikf)
-                endif
-
                 dEZeroth = dEEigElectron
 
                 

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -1024,7 +1024,7 @@ module energyTabulatorMod
     ! within the given bounds. If the Export files are found, read
     ! the energies. If not, set the state to be skipped. 
 
-    use TMEmod, only: readAllOptimalPairs
+    use optimalBandMatching, only: readAllOptimalPairs
 
     implicit none
 

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -1558,8 +1558,7 @@ module energyTabulatorMod
       open(27, file=trim(fName), status='unknown')
 
 
-      ! Ignore header lines
-      read(27,*)
+      ! Ignore header line
       read(27,*)
 
       do iUInit = 1, nUniqueInitStates

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -35,9 +35,9 @@ module energyTabulatorMod
 
   character(len=300) :: allStatesBaseDir_relaxed
     !! Base dir for sets of relaxed files if not captured
-  character(len=300) :: allStatesBaseDir_startPos
-    !! Base dir for different states in starting (ground-state)
-    !! positions if not captured
+  character(len=300) :: allStatesBaseDir_relaxPosGround
+    !! Base dir for each of the different relaxed positions
+    !! with ground-state configuration if not captured
   character(len=300) :: energyTableDir
     !! Path to energy tables
   character(len=300) :: exportDirEigs
@@ -65,7 +65,7 @@ module energyTabulatorMod
 !----------------------------------------------------------------------------
   subroutine readInputs(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
         ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
         singleStateExportDir, captured, elecCarrier, loopSpins)
 
     implicit none
@@ -95,9 +95,9 @@ module energyTabulatorMod
 
     character(len=300), intent(out) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(out) :: allStatesBaseDir_startPos
-      !! Base dir for different states in starting (ground-state)
-      !! positions if not captured
+    character(len=300), intent(out) :: allStatesBaseDir_relaxPosGround
+      !! Base dir for each of the different relaxed positions
+      !! with ground-state configuration if not captured
     character(len=300), intent(out) :: energyTableDir
       !! Path to energy tables
     character(len=300), intent(out) :: exportDirEigs
@@ -125,14 +125,14 @@ module energyTabulatorMod
     namelist /inputParams/ exportDirEigs, exportDirFinalFinal, exportDirFinalInit, exportDirInitInit, energyTableDir, &
                            eCorrectTot, eCorrectEigRef, captured, elecCarrier, ispSelect, allStatesBaseDir_relaxed, singleStateExportDir, &
                            iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, refBand, ikIinit, ikIfinal, ikFinit, ikFfinal, &
-                           ibShift_eig, allStatesBaseDir_startPos, dENegThresh, dEZeroThresh
+                           ibShift_eig, allStatesBaseDir_relaxPosGround, dENegThresh, dEZeroThresh
 
 
     if(ionode) then
 
       ! Set default values for input variables and start timers
       call initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, ispSelect, &
-            refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, allStatesBaseDir_startPos, &
+            refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, &
             energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, singleStateExportDir, &
             captured, elecCarrier)
     
@@ -144,7 +144,7 @@ module energyTabulatorMod
       ! Check that all variables were properly set
       call checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
             ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-            allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+            allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
             singleStateExportDir, captured, elecCarrier, loopSpins)
 
     endif
@@ -171,7 +171,7 @@ module energyTabulatorMod
     call MPI_BCAST(eCorrectEigRef, 1, MPI_DOUBLE_PRECISION, root, worldComm, ierr)
 
     call MPI_BCAST(allStatesBaseDir_relaxed, len(allStatesBaseDir_relaxed), MPI_CHARACTER, root, worldComm, ierr)
-    call MPI_BCAST(allStatesBaseDir_startPos, len(allStatesBaseDir_startPos), MPI_CHARACTER, root, worldComm, ierr)
+    call MPI_BCAST(allStatesBaseDir_relaxPosGround, len(allStatesBaseDir_relaxPosGround), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(energyTableDir, len(energyTableDir), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirEigs, len(exportDirEigs), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(exportDirInitInit, len(exportDirInitInit), MPI_CHARACTER, root, worldComm, ierr)
@@ -189,7 +189,7 @@ module energyTabulatorMod
 !----------------------------------------------------------------------------
   subroutine initialize(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
         ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
         singleStateExportDir, captured, elecCarrier)
     !! Set the default values for input variables and start timer
     !!
@@ -228,9 +228,9 @@ module energyTabulatorMod
 
     character(len=300), intent(out) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(out) :: allStatesBaseDir_startPos
-      !! Base dir for different states in starting (ground-state)
-      !! positions if not captured
+    character(len=300), intent(out) :: allStatesBaseDir_relaxPosGround
+      !! Base dir for each of the different relaxed positions
+      !! with ground-state configuration if not captured
     character(len=300), intent(out) :: energyTableDir
       !! Path to energy tables
     character(len=300), intent(out) :: exportDirEigs
@@ -272,7 +272,7 @@ module energyTabulatorMod
     eCorrectEigRef = 0.0_dp
 
     allStatesBaseDir_relaxed = ''
-    allStatesBaseDir_startPos = ''
+    allStatesBaseDir_relaxPosGround = ''
     energyTableDir = './'
     exportDirEigs = ''
     exportDirInitInit = ''
@@ -288,7 +288,7 @@ module energyTabulatorMod
 !----------------------------------------------------------------------------
   subroutine checkInitialization(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, ikFinit, ikFfinal, &
         ispSelect, refBand, dENegThresh, dEZeroThresh, eCorrectTot, eCorrectEigRef, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
+        allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, exportDirInitInit, exportDirFinalInit, exportDirFinalFinal, &
         singleStateExportDir, captured, elecCarrier, loopSpins)
 
     implicit none
@@ -318,9 +318,9 @@ module energyTabulatorMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for different states in starting (ground-state)
-      !! positions if not captured
+    character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
+      !! Base dir for each of the different relaxed positions
+      !! with ground-state configuration if not captured
     character(len=300), intent(in) :: energyTableDir
       !! Path to energy tables
     character(len=300), intent(in) :: exportDirEigs
@@ -393,7 +393,7 @@ module energyTabulatorMod
       abortExecution = checkIntInitialization('ikFfinal', ikFfinal, ikFinit, int(1e9)) .or. abortExecution 
 
       write(*,'("allStatesBaseDir_relaxed = ",a)') trim(allStatesBaseDir_relaxed)
-      write(*,'("allStatesBaseDir_startPos = ",a)') trim(allStatesBaseDir_startPos)
+      write(*,'("allStatesBaseDir_relaxPosGround = ",a)') trim(allStatesBaseDir_relaxPosGround)
       write(*,'("singleStateExportDir = ",a)') trim(singleStateExportDir)
       write(*,'("dENegThresh = ", ES12.3E3, " (eV)")') dENegThresh
       write(*,'("dEZeroThresh = ", ES12.3E3, " (eV)")') dEZeroThresh
@@ -710,7 +710,7 @@ module energyTabulatorMod
 !----------------------------------------------------------------------------
   subroutine calcAndWriteScatterEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ibShift_eig, ikIinit, ikIfinal, &
         ikFinit, ikFfinal, ispSelect, nSpins, refBand, dENegThresh, dEZeroThresh, eCorrectEigRef, elecCarrier, loopSpins, &
-        allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir, exportDirEigs, singleStateExportDir)
+        allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, energyTableDir, exportDirEigs, singleStateExportDir)
 
     implicit none
 
@@ -745,9 +745,9 @@ module energyTabulatorMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for different states in starting (ground-state)
-      !! positions if not captured
+    character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
+      !! Base dir for each of the different relaxed positions
+      !! with ground-state configuration if not captured
     character(len=300), intent(in) :: energyTableDir
       !! Path to energy tables
     character(len=300), intent(in) :: exportDirEigs
@@ -808,7 +808,7 @@ module energyTabulatorMod
       ! that they line up.
 
     call searchForStatesAndGetEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikIinit, ikIfinal, ikFInit, ikFfinal, &
-            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_startPos, singleStateExportDir, eTotRelax, &
+            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelax, &
             eTotStartPos, skipState)
 
 
@@ -979,7 +979,7 @@ module energyTabulatorMod
 
 !----------------------------------------------------------------------------
   subroutine searchForStatesAndGetEnergies(iBandIinit, iBandIfinal, iBandFinit, iBandFfinal, ikIinit, ikIfinal, ikFInit, ikFfinal, &
-            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_startPos, singleStateExportDir, eTotRelax, &
+            ikMin, ikMax, ibMin, ibMax, allStatesBaseDir_relaxed, allStatesBaseDir_relaxPosGround, singleStateExportDir, eTotRelax, &
             eTotStartPos, skipState)
     ! This subroutine searches for energy files for all states 
     ! within the given bounds. If the Export files are found, read
@@ -998,9 +998,9 @@ module energyTabulatorMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for different states in starting (ground-state)
-      !! positions if not captured
+    character(len=300), intent(in) :: allStatesBaseDir_relaxPosGround
+      !! Base dir for each of the different relaxed positions
+      !! with ground-state configuration if not captured
     character(len=300), intent(in) :: singleStateExportDir
       !! Export dir name within each subfolder
 
@@ -1059,7 +1059,7 @@ module energyTabulatorMod
 
               ! Get total energy for each state in start positions 
               ! (e.g., ground-state positions)
-              path = trim(allStatesBaseDir_startPos)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/'//trim(singleStateExportDir)
+              path = trim(allStatesBaseDir_relaxPosGround)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/'//trim(singleStateExportDir)
               call getTotalEnergy(path, eTotStartPos(ib,ik), fileExists)
 
               ! If both files exist, mark this state to not be skipped

--- a/EnergyTabulator/src/EnergyTabulator_module.f90
+++ b/EnergyTabulator/src/EnergyTabulator_module.f90
@@ -768,6 +768,8 @@ module energyTabulatorMod
 
     real(kind=dp) :: dEDelta
       !! Energy to be used in delta function
+    real(kind=dp) :: dEEigElectron
+      !! Eigenvalue difference f-i for actual electron
     real(kind=dp) :: dEFirst
       !! Energy to be used in first-order matrix element
     real(kind=dp) :: dEZeroth
@@ -905,10 +907,12 @@ module energyTabulatorMod
                 ! Because we use eigenvalues here, we must switch the order for different carriers
                 ! since it is assumed that the user will index the states based on the type of carrier.
                 if(elecCarrier) then
-                  dEZeroth = eigv(ibf+ibShift_eig,ikf) - eigv(ibi+ibShift_eig,iki)
+                  dEEigElectron = eigv(ibf+ibShift_eig,ikf) - eigv(ibi+ibShift_eig,iki)
                 else
-                  dEZeroth = eigv(ibi+ibShift_eig,iki) - eigv(ibf+ibShift_eig,ikf)
+                  dEEigElectron = eigv(ibi+ibShift_eig,iki) - eigv(ibf+ibShift_eig,ikf)
                 endif
+
+                dEZeroth = dEEigElectron
 
                 
                 if(abs(dEZeroth) < dEZeroThresh) then
@@ -930,7 +934,7 @@ module energyTabulatorMod
                 ! Because the zeroth-order term only has an eigenvalue difference, we can just
                 ! take the negative of that value. The sign doesn't actually matter because it
                 ! is squared in the matrix element, but we calculate it correctly for clarity.
-                dEFirst = -dEZeroth
+                dEFirst = -dEEigElectron
 
 
                 write(17,'(4i7,5ES24.15E3)') iki, ibi, ikf, ibf, dEDelta, dEZeroth, dEFirst, &

--- a/EnergyTabulator/src/Makefile
+++ b/EnergyTabulator/src/Makefile
@@ -7,7 +7,7 @@ MODFLAGS= -I$(CommonModules_srcPath) -I$(TME_srcPath) -I.
 DEBUGFLAGS = -check all -g -warn all -traceback -gen-interfaces 
 
 ENERGYTAB_OBJS = EnergyTabulator_module.o EnergyTabulator_main.o
-COMMONMODS = $(TME_srcPath)/TME_module.o $(CommonModules_srcPath)/commonmodules.a
+COMMONMODS = $(CommonModules_srcPath)/commonmodules.a
 
 all : EnergyTabulator.x 
 	
@@ -23,9 +23,7 @@ EnergyTabulator.x : mods $(COMMONMODS) $(ENERGYTAB_OBJS)
 
 mods :
 	cd $(CommonModules_srcPath) ; \
-	make ; \
-  cd $(TME_srcPath) ; \
-  make TMENoMods
+	make 
 
 %.o : %.f90
 	$(mpif90) $(MODFLAGS) -O3 -c -assume byterecl -fpp $<

--- a/EnergyTabulator/src/Makefile
+++ b/EnergyTabulator/src/Makefile
@@ -2,12 +2,12 @@
 -include ../../make.sys
 
 # location of needed modules
-MODFLAGS= -I$(CommonModules_srcPath) -I.
+MODFLAGS= -I$(CommonModules_srcPath) -I$(TME_srcPath) -I.
 
 DEBUGFLAGS = -check all -g -warn all -traceback -gen-interfaces 
 
 ENERGYTAB_OBJS = EnergyTabulator_module.o EnergyTabulator_main.o
-COMMONMODS = $(CommonModules_srcPath)/commonmodules.a
+COMMONMODS = $(TME_srcPath)/TME_module.o $(CommonModules_srcPath)/commonmodules.a
 
 all : EnergyTabulator.x 
 	
@@ -23,7 +23,9 @@ EnergyTabulator.x : mods $(COMMONMODS) $(ENERGYTAB_OBJS)
 
 mods :
 	cd $(CommonModules_srcPath) ; \
-	make
+	make ; \
+  cd $(TME_srcPath) ; \
+  make TMENoMods
 
 %.o : %.f90
 	$(mpif90) $(MODFLAGS) -O3 -c -assume byterecl -fpp $<

--- a/LSF/src/LSF_module.f90
+++ b/LSF/src/LSF_module.f90
@@ -883,8 +883,8 @@ contains
     ! Go through reading one file for capture and scattering in the
     ! same way but with different file names. This will get the
     ! Sj/Sj' and omega/omega'. For scattering, we only save the 
-    ! frequencies and number of modes from the first file because 
-    ! they do not depend on the transition
+    ! frequencies and number of modes from the first file and ignore
+    ! them in later files because they do not depend on the transition.
     if(captured) then
       fName = trim(SjBaseDir)//'/Sj.out' 
     else

--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,13 @@ initialize :
 		mkdir $(bin) ; \
 	fi
 
-
 # Define the targets
 TARGETS := Export_VASP EnergyTabulator TME PhononPP LSF
 
 # Define a pattern rule for all targets
 $(TARGETS) : initialize
-
-  @cd $($@_srcPath) ; \
-    make all
+	@cd $($@_srcPath) ; \
+	make all
 
 clean : cleanInitialization cleanExport_VASP cleanEnergyTabulator cleanGVel cleanTME cleanPhononPP cleanMj cleanLSF cleanSigma
 
@@ -105,5 +103,6 @@ cleanInitialization :
 # Define a pattern rule for cleaning targets
 clean% : initialize
 
-  @cd $($@_srcPath) ; \
-    make clean
+$(TARGETS) : initialize
+	@cd $($@_srcPath) ; \
+	make clean

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ EnergyTabulator_srcPath = EnergyTabulator/src
 TME_srcPath             = TME/src
 LSF_srcPath             = LSF/src
 PhononPP_srcPath        = PhononPP/src
+CommonModules_srcPath   = CommonModules
 
 bin = './bin'
 

--- a/PhononPP/README.md
+++ b/PhononPP/README.md
@@ -9,6 +9,7 @@ This code does post-processing of the phonons and relaxed structures. The curren
 * `generateShiftedPOSCARs` -- if POSCAR files shifted from given equilibium positions along the phonon modes should be output. These are used to get the first-order matrix element.
 * `calcMaxDisp` -- if the maximum displacement across modes between a pair of atoms given a `shift` should be calculated
 * `calcDeltaNj` -- if change of occupation numbers for carrier approach, transition, and departure should be calculated (only for scattering)
+* `readOptimalPairs` -- if optimal band pairs as output by `TME` code should be read from `optimalPairsDir` and states reshuffled.
 
 The code is structured so that each of the options above can be chosen independently. Each of the options and the inputs needed are given in more detail below. 
 
@@ -29,6 +30,8 @@ The code also always calculates the thermal occupation numbers $n_j$ based on an
 For all calculations that require projection onto the phonon eigenvectors, when `diffOmega = .true.` the user has the option to set `dqEigvecsFinal` to `.true.` or `.false.` to determine if the final (prime) mode eigenvectors will be used for the projections (`dqEigvecsFinal = .true.`) or the initial-mode eigenvectors (`.false.`). The default is `.true.`. Note that the `diffOmega` option has not been implemented for the scattering/multiple displacements case because the theory is not clear on what the different frequencies would be and we only consider a single set of frequencies for scattering. 
 
 With two sets of frequencies, care needs to be taken in determining how the input phonon files line up. In each phonon file, the modes are sorted by frequency, but that means the modes are most likely not going to be in the same order. In order to match up the modes in the different files, I have added a Hungarian optimization algorithm to maximize the total overlap between the phonon eigenvectors. The optimal choice for the pairings and the corresponding dot products are output in a file called `optimalPairs.out`. 
+
+The `optimalPairs.out` file output by `PhononPP` should not be confused with the `optimalPairsDir` output by `TME` to hold the optimal pairs between the band states. Here, the `readOptimalPairs` will read from those files and will affect the indices used to search for relaxed `CONTCAR` files for calculating $S_j$ and $\Delta n_j$. The `readOptimalPairs` option will only work for `singleDisp = .false.`. **All outputs by `PhononPP` are indexed properly if reshuffling the states so that no reshuffling is needed in `LSF`.**
 
 ### `calcSj`
 
@@ -54,7 +57,7 @@ For the scattering problem (`singleDisp = .false.`), we need to know how the occ
 ```
 where $\Delta E$ is the energy difference resulting from each process (tabulated in `EnergyTabulator`) and each process has its own $S_j$ corresponding to a different change in equilibrium positions $\Delta q_j$. For scattering, the displacement also depends on the electronic state because we relax each state separately. 
 
-To run this option, set `calcDeltaNj = .true.`, `singleDisp = .false.`, `calcSj = .true.`, and pass in the path to the total-energy calculations for each electronic state in the start/ground-state positions using `allStatesBaseDir_startPos`. It is assumed that the subfolder naming convention is `k<ik>_b<ib>` and lines up with those used for `EnergyTabulator`. The output files are named `deltaNj.k<iki>_b<ibi>.k<ikf>_b<ibf>.out` based on the initial/final bands and k-points and are stored in a subfolder called `deltaNjs`.
+To run this option, set `calcDeltaNj = .true.`, `singleDisp = .false.`, `calcSj = .true.`, and pass in the path to the relaxed states using  `allStatesBaseDir_relaxed` and the relaxed ground state using `basePOSCARFName`. It is assumed that the subfolder naming convention is `k<ik>_b<ib>` and lines up with those used for `EnergyTabulator` (with optional reshuffling using `readOptimalPairs` option). The output files are named `deltaNj.k<iki>_b<ibi>.k<ikf>_b<ibf>.out` based on the initial/final bands and k-points and are stored in a subfolder called `deltaNjs`. 
 
 ### First-order items
 

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -64,15 +64,31 @@ program PhononPPMain
   if(diffOmega) deallocate(eigenvectorPrime)
 
 
-  if(calcSj) &
-    call calculateSj(ispSelect, nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, omegaPrime, SjThresh, &
-            calcDeltaNj, diffOmega, singleDisp, allStatesBaseDir_relaxed, energyTableDir, initPOSCARFName, &
+  if(calcSj) then
+
+    if(.not. singleDisp) then
+      call readScatterEnergyTable(ispSelect, .false., energyTableDir, ibi, ibf, iki, ikf, nTransitions, dE)
+        ! Pass false here to get all of the energies
+    endif
+
+    call calculateSj(nAtoms, nModes, nTransitions, iki, ikf, ibi, ibf, coordFromPhon, dqEigenvectors, mass, &
+            omega, omegaPrime, SjThresh, calcDeltaNj, diffOmega, singleDisp, allStatesBaseDir_relaxed, initPOSCARFName, & 
             finalPOSCARFName, Sj_if)
 
 
-  if(calcSj .and. (.not. singleDisp) .and. calcDeltaNj) &
-    call calcAndWriteDeltaNj(ispSelect, nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, Sj_if, &
-            allStatesBaseDir_relaxed, basePOSCARFName, energyTableDir)
+    if((.not. singleDisp) .and. calcDeltaNj) &
+      call calcAndWriteDeltaNj(nAtoms, nModes, nTransitions, iki, ikf, ibi, ibf, coordFromPhon, dE, &
+              dqEigenvectors, mass, omega, Sj_if, allStatesBaseDir_relaxed, basePOSCARFName)
+
+
+    if(.not. singleDisp) then
+      deallocate(iki)
+      deallocate(ikf)
+      deallocate(ibi)
+      deallocate(ibf)
+      deallocate(dE)
+    endif
+  endif
 
 
   deallocate(Sj_if)

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -13,8 +13,8 @@ program PhononPPMain
 
   call readInputs(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
         basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, &
-        initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, &
-        generateShiftedPOSCARs, singleDisp)
+        initPOSCARFName, optimalPairsDir, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, &
+        dqEigvecsFinal, generateShiftedPOSCARs, readOptimalPairs, singleDisp)
 
 
   call readPhonons(freqThresh, phononFName, nAtoms, nModes, coordFromPhon, eigenvector, mass, omega)

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -69,6 +69,8 @@ program PhononPPMain
     if(.not. singleDisp) then
       call readScatterEnergyTable(ispSelect, .false., energyTableDir, ibi, ibf, iki, ikf, nTransitions, dE)
         ! Pass false here to get all of the energies
+
+      if(readOptimalPairs) call readOptimalPairsUniqueK(nTransitions, iki, ikf, optimalPairsDir, ibDefect_optimal)
     endif
 
     call calculateSj(nAtoms, nModes, nTransitions, iki, ikf, ibi, ibf, coordFromPhon, dqEigenvectors, mass, &

--- a/PhononPP/src/PhononPP_main.f90
+++ b/PhononPP/src/PhononPP_main.f90
@@ -12,9 +12,9 @@ program PhononPPMain
   call mpiInitialization('PhononPP')
 
   call readInputs(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, &
-        finalPOSCARFName, initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, &
-        dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
+        basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, &
+        initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, &
+        generateShiftedPOSCARs, singleDisp)
 
 
   call readPhonons(freqThresh, phononFName, nAtoms, nModes, coordFromPhon, eigenvector, mass, omega)
@@ -72,7 +72,7 @@ program PhononPPMain
 
   if(calcSj .and. (.not. singleDisp) .and. calcDeltaNj) &
     call calcAndWriteDeltaNj(ispSelect, nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, Sj_if, &
-            allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir)
+            allStatesBaseDir_relaxed, basePOSCARFName, energyTableDir)
 
 
   deallocate(Sj_if)

--- a/PhononPP/src/PhononPP_module.f90
+++ b/PhononPP/src/PhononPP_module.f90
@@ -61,9 +61,6 @@ module PhononPPMod
 
   character(len=300) :: allStatesBaseDir_relaxed
     !! Base dir for sets of relaxed files if not captured
-  character(len=300) :: allStatesBaseDir_startPos
-    !! Base dir for total energies of each electronic state
-    !! in the starting positions if not captured
   character(len=300) :: basePOSCARFName
     !! File name for intial POSCAR to calculate shift from
   character(len=300) :: dqFName
@@ -99,9 +96,8 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine readInputs(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, &
-        finalPOSCARFName, initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, &
-        dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
+        basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, initPOSCARFName, &
+        prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
 
     implicit none
 
@@ -123,9 +119,6 @@ module PhononPPMod
 
     character(len=300), intent(out) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(out) :: allStatesBaseDir_startPos
-      !! Base dir for total energies of each electronic state
-      !! in the starting positions if not captured
     character(len=300), intent(out) :: basePOSCARFName
       !! File name for intial POSCAR to calculate shift from
     character(len=300), intent(out) :: dqFName
@@ -162,15 +155,14 @@ module PhononPPMod
     namelist /inputParams/ initPOSCARFName, finalPOSCARFName, phononFName, prefix, shift, dqFName, generateShiftedPOSCARs, &
                            singleDisp, allStatesBaseDir_relaxed, basePOSCARFName, freqThresh, calcSj, calcDq, calcMaxDisp, & 
                            disp2AtomInd, energyTableDir, diffOmega, phononPrimeFName, dqEigvecsFinal, SjThresh, &
-                           temperature, calcDeltaNj, allStatesBaseDir_startPos, ispSelect
+                           temperature, calcDeltaNj, ispSelect
 
 
     if(ionode) then
 
       call initialize(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-          allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, &
-          finalPOSCARFName, initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, &
-          dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
+          basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, initPOSCARFName, &
+          prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
         ! Set default values for input variables and start timers
     
       read(5, inputParams, iostat=ierr)
@@ -180,9 +172,8 @@ module PhononPPMod
         !! * Exit calculation if there's an error
 
       call checkInitialization(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-        allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, &
-        initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, &
-        generateShiftedPOSCARs, singleDisp)
+        basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, initPOSCARFName, prefix, &
+        calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
 
     endif
 
@@ -197,7 +188,6 @@ module PhononPPMod
 
     call MPI_BCAST(basePOSCARFName, len(basePOSCARFName), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(allStatesBaseDir_relaxed, len(allStatesBaseDir_relaxed), MPI_CHARACTER, root, worldComm, ierr)
-    call MPI_BCAST(allStatesBaseDir_startPos, len(allStatesBaseDir_startPos), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(energyTableDir, len(energyTableDir), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(finalPOSCARFName, len(finalPOSCARFName), MPI_CHARACTER, root, worldComm, ierr)
     call MPI_BCAST(initPOSCARFName, len(initPOSCARFName), MPI_CHARACTER, root, worldComm, ierr)
@@ -218,9 +208,8 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine initialize(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-      allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, &
-      finalPOSCARFName, initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, &
-      dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
+      basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, initPOSCARFName, &
+      prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
     !! Set the default values for input variables, open output files,
     !! and start timer
     !!
@@ -247,9 +236,6 @@ module PhononPPMod
 
     character(len=300), intent(out) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(out) :: allStatesBaseDir_startPos
-      !! Base dir for total energies of each electronic state
-      !! in the starting positions if not captured
     character(len=300), intent(out) :: basePOSCARFName
       !! File name for intial POSCAR to calculate shift from
     character(len=300), intent(out) :: dqFName
@@ -287,7 +273,6 @@ module PhononPPMod
     ispSelect = -1
 
     allStatesBaseDir_relaxed = ''
-    allStatesBaseDir_startPos = ''
     dqFName = 'dq.txt'
     energyTableDir = ''
     basePOSCARFName = ''
@@ -317,9 +302,8 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine checkInitialization(disp2AtomInd, ispSelect, freqThresh, shift, SjThresh, temperature, allStatesBaseDir_relaxed, &
-      allStatesBaseDir_startPos, basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, &
-      initPOSCARFName, prefix, calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, &
-      generateShiftedPOSCARs, singleDisp)
+      basePOSCARFName, dqFName, energyTableDir, phononFName, phononPrimeFName, finalPOSCARFName, initPOSCARFName, prefix, &
+      calcDeltaNj, calcDq, calcMaxDisp, calcSj, diffOmega, dqEigvecsFinal, generateShiftedPOSCARs, singleDisp)
 
     implicit none
 
@@ -341,9 +325,6 @@ module PhononPPMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for total energies of each electronic state
-      !! in the starting positions if not captured
     character(len=300), intent(inout) :: basePOSCARFName
       !! File name for intial POSCAR to calculate shift from
     character(len=300), intent(in) :: dqFName
@@ -403,7 +384,8 @@ module PhononPPMod
 
         write(*,'("allStatesBaseDir_relaxed = ''",a,"''")') trim(allStatesBaseDir_relaxed)
         write(*,'("calcDeltaNj = ''",L1,"''")') calcDeltaNj
-        if(calcDeltaNj) write(*,'("allStatesBaseDir_startPos = ''",a,"''")') trim(allStatesBaseDir_startPos)
+        if(calcDeltaNj) &
+          abortExecution = checkFileInitialization('basePOSCARFName', basePOSCARFName) .or. abortExecution
 
         abortExecution = checkIntInitialization('ispSelect', ispSelect, 1, 2) .or. abortExecution
         abortExecution = checkFileInitialization('energyTableDir', trim(energyTableDir)//'/energyTable.'&
@@ -434,12 +416,22 @@ module PhononPPMod
 
       abortExecution = checkDoubleInitialization('shift', shift, 0.0_dp, 10.0_dp) .or. abortExecution
       
-      if(trim(basePOSCARFName) == '') then
-        write(*,'("No input detected for basePOSCARFName! Defaulting to input value for initPOSCARFName.")')
-        basePOSCARFName = initPOSCARFName
-      endif
+      ! Only default to the initial relaxed positions for a single displacement
+      ! because otherwise there may not be a single set of "initial positions"
+      if(singleDisp) then
+        if(trim(basePOSCARFName) == '') then
+          write(*,'("No input detected for basePOSCARFName! Defaulting to input value for initPOSCARFName.")')
+          basePOSCARFName = initPOSCARFName
+        endif
 
-      abortExecution = checkFileInitialization('basePOSCARFName', basePOSCARFName) .or. abortExecution
+        abortExecution = checkFileInitialization('basePOSCARFName', basePOSCARFName) .or. abortExecution
+
+      ! calcDeltaNj requires basePOSCAR to know what the base (e.g., ground
+      ! state) positions are, so the file is already checked above, so only 
+      ! check for it here if it hasn't already been checked for.
+      else if(.not. calcDeltaNj) then
+        abortExecution = checkFileInitialization('basePOSCARFName', basePOSCARFName) .or. abortExecution
+      endif
     endif
 
     ! Need for calculating max displacement:
@@ -975,7 +967,7 @@ module PhononPPMod
         ! I pass false here because it means only three energies will be 
         ! passed back, which is smaller than the five  passed back from 
         ! the true option. We ignore the energies here, so it doesn't 
-        ! matter.
+        ! matter. All we need from this call is the state indices.
 
       if(ionode) then
 
@@ -1475,7 +1467,7 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine calcAndWriteDeltaNj(ispSelect, nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, Sj_if, &
-            allStatesBaseDir_relaxed, allStatesBaseDir_startPos, energyTableDir)
+            allStatesBaseDir_relaxed, basePOSCARFName, energyTableDir)
 
     implicit none
 
@@ -1502,9 +1494,8 @@ module PhononPPMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for total energies of each electronic state
-      !! in the starting positions if not captured
+    character(len=300), intent(in) :: basePOSCARFName
+      !! File name for intial POSCAR to calculate shift from
     character(len=300), intent(in) :: energyTableDir
       !! Path to energy table
 
@@ -1538,12 +1529,12 @@ module PhononPPMod
 
       ! Pass true to indicate that this adjustment is ground/start positions to initial-state
       call getEqAdjustSj(iki(iE), ibi(iE), nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, .true., &
-              allStatesBaseDir_relaxed, allStatesBaseDir_startPos, Sj_gi)
+              allStatesBaseDir_relaxed, basePOSCARFName, Sj_gi)
 
 
       ! Pass false to indicate that this adjustment is final-state positions to ground/start
       call getEqAdjustSj(ikf(iE), ibf(iE), nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, .false., &
-              allStatesBaseDir_relaxed, allStatesBaseDir_startPos, Sj_fg)
+              allStatesBaseDir_relaxed, basePOSCARFName, Sj_fg)
 
       if(ionode) then
         ! Set output file name
@@ -1584,7 +1575,7 @@ module PhononPPMod
 
 !----------------------------------------------------------------------------
   subroutine getEqAdjustSj(ik, ib, nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, omega, startToRelaxed, &
-          allStatesBaseDir_relaxed, allStatesBaseDir_startPos, Sj)
+          allStatesBaseDir_relaxed, basePOSCARFName, Sj)
 
     implicit none
 
@@ -1612,9 +1603,8 @@ module PhononPPMod
 
     character(len=300), intent(in) :: allStatesBaseDir_relaxed
       !! Base dir for sets of relaxed files if not captured
-    character(len=300), intent(in) :: allStatesBaseDir_startPos
-      !! Base dir for total energies of each electronic state
-      !! in the starting positions if not captured
+    character(len=300), intent(in) :: basePOSCARFName
+      !! File name for intial POSCAR to calculate shift from
 
     ! Output variables:
     real(kind=dp), intent(out) :: Sj(nModes)
@@ -1632,9 +1622,6 @@ module PhononPPMod
     logical :: fileExists
       !! If a file exists
 
-    character(len=300) :: startPOSCARFName
-      !! File name for POSCAR for this state ik, ib
-      !! in the starting positions
     character(len=300) :: relaxedPOSCARFName
       !! File name for POSCAR for this state ik, ib
       !! in its relaxed positions
@@ -1642,10 +1629,6 @@ module PhononPPMod
 
 
     if(ionode) then
-      startPOSCARFName = trim(allStatesBaseDir_startPos)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/CONTCAR'
-      inquire(file=trim(startPOSCARFName), exist=fileExists)
-      if(.not. fileExists) call exitError('calcSingleDispDeltaNjEqAdjust', 'File does not exist!! '//trim(startPOSCARFName), 1)
-
       relaxedPOSCARFName = trim(allStatesBaseDir_relaxed)//'/k'//trim(int2str(ik))//'_b'//trim(int2str(ib))//'/CONTCAR'
       inquire(file=trim(relaxedPOSCARFName), exist=fileExists)
       if(.not. fileExists) call exitError('calcSingleDispDeltaNjEqAdjust', 'File does not exist!! '//trim(relaxedPOSCARFName), 1)
@@ -1656,9 +1639,9 @@ module PhononPPMod
     ! (initial carrier approach), then pass the start positions first.
     ! Otherwise (carrier leaving), pass the relaxed positions first.
     if(startToRelaxed) then
-      call getSingleDispProjNormAllModes(nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, startPOSCARFName, relaxedPOSCARFName, projNorm)
+      call getSingleDispProjNormAllModes(nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, basePOSCARFName, relaxedPOSCARFName, projNorm)
     else
-      call getSingleDispProjNormAllModes(nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, relaxedPOSCARFName, startPOSCARFName, projNorm)
+      call getSingleDispProjNormAllModes(nAtoms, nModes, coordFromPhon, dqEigenvectors, mass, relaxedPOSCARFName, basePOSCARFName, projNorm)
     endif
 
 

--- a/TME/src/Makefile
+++ b/TME/src/Makefile
@@ -21,6 +21,15 @@ TME.x : mods $(COMMONMODS) $(TME_OBJS)
 	echo "" ; \
 	echo "" ; 
 
+TMENoMods : $(COMMONMODS) $(TME_OBJS)
+	$(mpif90) $(MODFLAGS) -o TME.x $(TME_OBJS) $(COMMONMODS)
+
+	@echo "" ; \
+	echo "" ; \
+	echo "Module 'TME' compiled successfully !" ; \
+	echo "" ; \
+	echo "" ; 
+
 mods :
 	cd $(CommonModules_srcPath) ; \
 	make ; \

--- a/TME/src/Makefile
+++ b/TME/src/Makefile
@@ -21,15 +21,6 @@ TME.x : mods $(COMMONMODS) $(TME_OBJS)
 	echo "" ; \
 	echo "" ; 
 
-TMENoMods : $(COMMONMODS) $(TME_OBJS)
-	$(mpif90) $(MODFLAGS) -o TME.x $(TME_OBJS) $(COMMONMODS)
-
-	@echo "" ; \
-	echo "" ; \
-	echo "Module 'TME' compiled successfully !" ; \
-	echo "" ; \
-	echo "" ; 
-
 mods :
 	cd $(CommonModules_srcPath) ; \
 	make ; \

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -21,7 +21,7 @@ program TMEmain
 
   call readInputParams(iBandLBra, iBandHBra, iBandLKet, iBandHKet, ibBra, ikBra, ibKet, ikKet, ibShift_braket, &
           ispSelect, nPairs, order, phononModeJ, baselineDir, braExportDir, ketExportDir, dqFName, energyTableDir, &
-          outputDir, capture, dqOnly, intraK, lineUpBands, overlapOnly, subtractBaseline)
+          optimalPairsDir, outputDir, capture, dqOnly, intraK, lineUpBands, overlapOnly, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     
@@ -44,7 +44,7 @@ program TMEmain
           crystalSystem(2), pot)
   else if(overlapOnly .and. .not. intraK) then
     call getAndWriteInterKOnlyOverlaps(iBandLBra, iBandHBra, iBandLKet, iBandHKet, nPairs, ibBra, ibKet, &
-            ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, crystalSystem(1), crystalSystem(2), pot)
+            ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, optimalPairsDir, crystalSystem(1), crystalSystem(2), pot)
   else
     call getAndWriteScatterMatrixElementsOrOverlaps(nPairs, ibKet, ikKet, ibBra, ikBra, ispSelect, nGVecsLocal, nSpins, &
             volume, overlapOnly, crystalSystem(1), crystalSystem(2), pot)

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -44,10 +44,11 @@ program TMEmain
           dqOnly, crystalSystem(1), crystalSystem(2), pot)
   else if(overlapOnly .and. .not. intraK) then
     call getAndWriteInterKOnlyOverlaps(iBandLBra, iBandHBra, iBandLKet, iBandHKet, nPairs, ibShift_braket, ibBra, ibKet, &
-            ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, optimalPairsDir, crystalSystem(1), crystalSystem(2), pot)
+            ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, readOptimalPairs, optimalPairsDir, crystalSystem(1), &
+            crystalSystem(2), pot)
   else
     call getAndWriteScatterMatrixElementsOrOverlaps(nPairs, ibShift_braket, ibKet, ikKet, ibBra, ikBra, ispSelect, nGVecsLocal, nSpins, &
-            volume, overlapOnly, crystalSystem(1), crystalSystem(2), pot)
+            volume, overlapOnly, readOptimalPairs, optimalPairsDir, crystalSystem(1), crystalSystem(2), pot)
   endif 
 
 

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -19,9 +19,9 @@ program TMEmain
   if(ionode) call cpu_time(t0)
 
 
-  call readInputParams(ibBra, ikBra, ibKet, ikKet, ibShift_braket, ispSelect, nPairs, order, phononModeJ, baselineDir, &
-          braExportDir, ketExportDir, dqFName, energyTableDir, outputDir, capture, dqOnly, intraK, lineUpBands, &
-          overlapOnly, subtractBaseline)
+  call readInputParams(iBandLBra, iBandHBra, iBandLKet, iBandHKet, ibBra, ikBra, ibKet, ikKet, ibShift_braket, &
+          ispSelect, nPairs, order, phononModeJ, baselineDir, braExportDir, ketExportDir, dqFName, energyTableDir, &
+          outputDir, capture, dqOnly, intraK, lineUpBands, overlapOnly, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     
@@ -43,7 +43,8 @@ program TMEmain
     call getAndWriteCaptureMatrixElements(nPairs, ibKet, ibBra(1), ispSelect, nGVecsLocal, nSpins, dq_j, volume, dqOnly, crystalSystem(1), & 
           crystalSystem(2), pot)
   else if(overlapOnly .and. .not. intraK) then
-    call getAndWriteInterKOnlyOverlaps(nPairs, ibBra, ibKet, ispSelect, nGVecsLocal, nSpins, volume, crystalSystem(1), crystalSystem(2), pot)
+    call getAndWriteInterKOnlyOverlaps(iBandLBra, iBandHBra, iBandLKet, iBandHKet, nPairs, ibBra, ibKet, &
+            ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, crystalSystem(1), crystalSystem(2), pot)
   else
     call getAndWriteScatterMatrixElementsOrOverlaps(nPairs, ibKet, ikKet, ibBra, ikBra, ispSelect, nGVecsLocal, nSpins, &
             volume, overlapOnly, crystalSystem(1), crystalSystem(2), pot)

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -20,7 +20,8 @@ program TMEmain
 
 
   call readInputParams(ibBra, ikBra, ibKet, ikKet, ibShift_braket, ispSelect, nPairs, order, phononModeJ, baselineDir, &
-          braExportDir, ketExportDir, dqFName, energyTableDir, outputDir, capture, dqOnly, intraK, overlapOnly, subtractBaseline)
+          braExportDir, ketExportDir, dqFName, energyTableDir, outputDir, capture, dqOnly, intraK, lineUpBands, &
+          overlapOnly, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -28,7 +28,7 @@ program TMEmain
 
   nSys = 2
 
-  call setUpSystemArray(ibShift_braket, nSys, braExportDir, ketExportDir, crystalSystem)
+  call setUpSystemArray(nSys, braExportDir, ketExportDir, crystalSystem)
     ! This is not really needed for only 2 crystal systems. We don't actually
     ! need it right now because for scattering we plan to only read from 2 exports.
     ! However, it is possible that you could read from multiple exports for the
@@ -40,13 +40,13 @@ program TMEmain
 
   
   if(capture) then
-    call getAndWriteCaptureMatrixElements(nPairs, ibKet, ibBra(1), ispSelect, nGVecsLocal, nSpins, dq_j, volume, dqOnly, crystalSystem(1), & 
-          crystalSystem(2), pot)
+    call getAndWriteCaptureMatrixElements(nPairs, ibShift_braket, ibKet, ibBra(1), ispSelect, nGVecsLocal, nSpins, dq_j, volume, &
+          dqOnly, crystalSystem(1), crystalSystem(2), pot)
   else if(overlapOnly .and. .not. intraK) then
-    call getAndWriteInterKOnlyOverlaps(iBandLBra, iBandHBra, iBandLKet, iBandHKet, nPairs, ibBra, ibKet, &
+    call getAndWriteInterKOnlyOverlaps(iBandLBra, iBandHBra, iBandLKet, iBandHKet, nPairs, ibShift_braket, ibBra, ibKet, &
             ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, optimalPairsDir, crystalSystem(1), crystalSystem(2), pot)
   else
-    call getAndWriteScatterMatrixElementsOrOverlaps(nPairs, ibKet, ikKet, ibBra, ikBra, ispSelect, nGVecsLocal, nSpins, &
+    call getAndWriteScatterMatrixElementsOrOverlaps(nPairs, ibShift_braket, ibKet, ikKet, ibBra, ikBra, ispSelect, nGVecsLocal, nSpins, &
             volume, overlapOnly, crystalSystem(1), crystalSystem(2), pot)
   endif 
 

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -21,7 +21,7 @@ program TMEmain
 
   call readInputParams(iBandLBra, iBandHBra, iBandLKet, iBandHKet, ibBra, ikBra, ibKet, ikKet, ibShift_braket, &
           ispSelect, nPairs, order, phononModeJ, baselineDir, braExportDir, ketExportDir, dqFName, energyTableDir, &
-          optimalPairsDir, outputDir, capture, dqOnly, intraK, lineUpBands, overlapOnly, subtractBaseline)
+          optimalPairsDir, outputDir, capture, dqOnly, intraK, lineUpBands, overlapOnly, readOptimalPairs, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     

--- a/TME/src/TME_main.f90
+++ b/TME/src/TME_main.f90
@@ -19,15 +19,15 @@ program TMEmain
   if(ionode) call cpu_time(t0)
 
 
-  call readInputParams(ibBra, ikBra, ibKet, ikKet, ispSelect, nPairs, order, phononModeJ, baselineDir, braExportDir, &
-          ketExportDir, dqFName, energyTableDir, outputDir, capture, dqOnly, intraK, overlapOnly, subtractBaseline)
+  call readInputParams(ibBra, ikBra, ibKet, ikKet, ibShift_braket, ispSelect, nPairs, order, phononModeJ, baselineDir, &
+          braExportDir, ketExportDir, dqFName, energyTableDir, outputDir, capture, dqOnly, intraK, overlapOnly, subtractBaseline)
     !! Read input, initialize, check that required variables were set, and
     !! distribute across processes
     
 
   nSys = 2
 
-  call setUpSystemArray(nSys, braExportDir, ketExportDir, crystalSystem)
+  call setUpSystemArray(ibShift_braket, nSys, braExportDir, ketExportDir, crystalSystem)
     ! This is not really needed for only 2 crystal systems. We don't actually
     ! need it right now because for scattering we plan to only read from 2 exports.
     ! However, it is possible that you could read from multiple exports for the

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -1889,7 +1889,7 @@ contains
         
         if(readOptimalPairs) then
           if(indexInPool == 0) &
-            call readAllOptimalPairs(ikGlobal, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
+            call readAllOptimalPairs(ikGlobal, nSpins, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
                   ibBra_optimal)
 
           call MPI_BCAST(iBandLKet, 1, MPI_INTEGER, root, intraPoolComm, ierr)
@@ -2199,7 +2199,7 @@ contains
         
           if(readOptimalPairs) then
             if(ionode) &
-              call readAllOptimalPairs(ikfUnique(iU_ikf), spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
+              call readAllOptimalPairs(ikfUnique(iU_ikf), nSpins, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
                     ibBra_optimal)
 
             call MPI_BCAST(iBandLKet, 1, MPI_INTEGER, root, worldComm, ierr)
@@ -3414,7 +3414,7 @@ contains
   end subroutine findOptimalPairsAndOutput
 
 !----------------------------------------------------------------------------
-  subroutine readAllOptimalPairs(ikGlobal, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
+  subroutine readAllOptimalPairs(ikGlobal, nSpins, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
         ibBra_optimal)
     ! The optimal pairs file contains the best match between the bra-system (defect)
     ! and ket-system (perfect crystal) state indices. Because we take the energies 
@@ -3432,6 +3432,9 @@ contains
     ! Input variables:
     integer, intent(in) :: ikGlobal
       !! Current global k-point
+    integer, intent(in) :: nSpins
+      !! Number of spins (tested to be consistent
+      !! across all systems)
 
     logical, intent(in) :: spin1Skipped, spin2Skipped
       !! If spin channels skipped

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -1796,6 +1796,8 @@ contains
           ibBra, ibKet, ispSelect, nGVecsLocal, nSpins, volume, lineUpBands, readOptimalPairs, optimalPairsDir, &
           braSys, ketSys, pot)
 
+    use optimalBandMatching, only: findOptimalPairsAndOutput, readAllOptimalPairs
+
     implicit none
 
     ! Input variables:
@@ -2076,6 +2078,8 @@ contains
 !----------------------------------------------------------------------------
   subroutine getAndWriteScatterMatrixElementsOrOverlaps(nTransitions, ibShift_braket, ibi, iki, ibf, ikf, ispSelect, &
             nGVecsLocal, nSpins, volume, overlapOnly, readOptimalPairs, optimalPairsDir, braSys, ketSys, pot)
+
+    use optimalBandMatching, only: readAllOptimalPairs
 
     implicit none
 
@@ -3328,165 +3332,6 @@ contains
     return
     
   end subroutine writeInterKOverlaps
-
-!----------------------------------------------------------------------------
-  subroutine findOptimalPairsAndOutput(iBandLBra, iBandHBra, iBandLKet, iBandHKet, ikLocal, isp, nPairs, Ufi, optimalPairsDir)
-
-    use hungarianOptimizationMod, only: hungarianOptimalMatching
-
-    implicit none
-
-    ! Input variables:
-    integer, intent(in) :: iBandLBra, iBandHBra, iBandLKet, iBandHKet
-      !! Optional band bounds
-    integer, intent(in) :: ikLocal
-      !! Current local k-point
-    integer, intent(in) :: isp
-      !! Current spin channel
-    integer, intent(in) :: nPairs
-      !! Number of pairs of bands to get overlaps for
-
-    complex(kind=dp), intent(in) :: Ufi(nPairs)
-      !! All-electron overlap
-
-    character(len=300), intent(in) :: optimalPairsDir
-      !! Path to store or read optimalPairs.out file
-
-    ! Local variables:
-    integer :: ikGlobal
-      !! Current global k-point
-    integer :: ip, ibB, ibK
-      !! Loop indices
-    integer, allocatable :: maxBandPair(:)
-      !! Optimal band pair to maximize overlaps
-    integer :: nBandsEachSys
-      !! Number of bands per system (bra/ket) to line up
-
-    real(kind=dp), allocatable :: norm2Ufi2D(:,:)
-      !! 2D version of overlap array (needed for passing
-      !! into optimization subroutine)
-    real(kind=dp) :: t1, t2
-
-
-    nBandsEachSys = (iBandHBra - iBandLBra + 1)
-      ! Doesn't matter which system you use here because we already
-      ! confirmed that they have the same number
-
-    allocate(norm2Ufi2D(nBandsEachSys,nBandsEachSys))
-
-    ip = 0
-    do ibB = 1, nBandsEachSys
-      do ibK = 1, nBandsEachSys
-        ip = ip + 1
-        norm2Ufi2D(ibB,ibK) = abs(Ufi(ip))**2
-      enddo
-    enddo
-
-
-    allocate(maxBandPair(nBandsEachSys))
-
-    if(ionode) write(*,'("  Beginning optimal matching algorithm to match ",i7," sets of bands.")') nBandsEachSys
-    call cpu_time(t1)
-
-    call hungarianOptimalMatching(nBandsEachSys, norm2Ufi2D, .false., maxBandPair)
-
-    call cpu_time(t2)
-    if(ionode) write(*,'("  Optimal matching complete! (",f10.2," secs)")') t2-t1
-
-
-    ikGlobal = ikLocal+ikStart_pool-1
-
-    open(64,file=trim(optimalPairsDir)//'/optimalPairs.'//trim(int2str(isp))//'.'//trim(int2str(ikGlobal))//'.out')
-
-    write(64,'("# Number of bands in each system, iBandLBra, iBandHBra, iBandLKet, iBandHKet")')
-    write(64,'(5i10)') nBandsEachSys, iBandLBra, iBandHBra, iBandLKet, iBandHKet
-
-    write(64,'("# ibBra, ibKet, Overlap")')
-
-    do ibK = 1, nBandsEachSys ! Loop over second (col) index
-      write(64,'(2i10,ES13.4E3)') maxBandPair(ibK)+iBandLBra-1, ibK+iBandLKet-1, norm2Ufi2D(maxBandPair(ibK),ibK) 
-    enddo
-
-    close(64)
-
-    return
-
-  end subroutine findOptimalPairsAndOutput
-
-!----------------------------------------------------------------------------
-  subroutine readAllOptimalPairs(ikGlobal, nSpins, spin1Skipped, spin2Skipped, optimalPairsDir, iBandLKet, iBandHKet, &
-        ibBra_optimal)
-    ! The optimal pairs file contains the best match between the bra-system (defect)
-    ! and ket-system (perfect crystal) state indices. Because we take the energies 
-    ! from the perfect-crystal system, I do not rearrange those states. Instead, 
-    ! I find the corresponding match from the defect system. 
-    !
-    ! This file can be confusing because the indices come from the defect system, 
-    ! but the perfect-crystal-system states are not shifted while those from the
-    ! defect system are. I tried to think of a way around this, but using the defect
-    ! indices just makes sense so that all of the codes can work consistently with
-    ! the zeroth- and first-order term, with the latter containing only defect states.
-
-    implicit none
-
-    ! Input variables:
-    integer, intent(in) :: ikGlobal
-      !! Current global k-point
-    integer, intent(in) :: nSpins
-      !! Number of spins (tested to be consistent
-      !! across all systems)
-
-    logical, intent(in) :: spin1Skipped, spin2Skipped
-      !! If spin channels skipped
-
-    character(len=300), intent(in) :: optimalPairsDir
-      !! Path to store or read optimalPairs.out file
-
-    ! Output variables:
-    integer, intent(out) :: iBandLKet, iBandHKet
-      !! Band bounds from optimalPairs file
-    integer, allocatable, intent(out) :: ibBra_optimal(:,:)
-      !! Optimal index from the bra system corresponding 
-      !! to the input index from the ket system
-
-    ! Local variables:
-    integer :: iBandLBra, iBandHBra
-      !! Band bounds from optimalPairs file
-    integer :: isp, ibp, ibKet, ibBra
-      !! Loop indices
-    integer :: nBandsEachSys
-      !! Number of bands per system (bra/ket) to line up
-
-
-    do isp = 1, nSpins
-      if((isp == 1 .and. .not. spin1Skipped) .or. (isp == 2 .and. .not. spin2Skipped)) then
-
-        open(64,file=trim(optimalPairsDir)//'/optimalPairs.'//trim(int2str(isp))//'.'//trim(int2str(ikGlobal))//'.out')
-
-        read(64,*)
-        read(64,'(5i10)') nBandsEachSys, iBandLBra, iBandHBra, iBandLKet, iBandHKet
-
-        if(isp == 1 .or. spin1Skipped) allocate(ibBra_optimal(nSpins,iBandLKet:iBandHKet))
-          ! Assume that the band bounds are the same for both spin channels, which
-          ! should currently be the case unless the user messes with the files
-
-
-        read(64,*)
-
-        do ibp = 1, nBandsEachSys
-          read(64,*) ibBra, ibKet
-          ibBra_optimal(isp,ibKet) = ibBra
-            ! Storing it like this means it will work even if the 
-            ! band pairs get reordered somehow
-        enddo
-
-        close(64)
-      endif
-    enddo
-
-    return
-
-  end subroutine readAllOptimalPairs
    
 !----------------------------------------------------------------------------
   subroutine bessel_j (x, lmax, jl)

--- a/TME/src/TME_module.f90
+++ b/TME/src/TME_module.f90
@@ -1913,8 +1913,9 @@ contains
             call exitError('getAndWriteInterKOnlyOverlaps',&
               'Index '//trim(int2str(ibBra(ip)))//' not included in optimalPairs file for ik = '//trim(int2str(ikGlobal)),1)
 
-          call calculateBandPairOverlap(ibShift_braket, ibBra(ip), ibKet(ip), ikGlobal, ikGlobal, nSpins, ibBra_optimal, &
-                nGVecsLocal, volume, readOptimalPairs, spin1Skipped, spin2Skipped, braSys, ketSys, pot, Ufi_ip)
+          call calculateBandPairOverlap(ibShift_braket, ibBra(ip), ibKet(ip), ikGlobal, ikGlobal, nSpins, &
+                ibBra_optimal(:,ibBra(ip)), nGVecsLocal, volume, readOptimalPairs, spin1Skipped, spin2Skipped, &
+                braSys, ketSys, pot, Ufi_ip)
 
           Ufi(ip,:) = Ufi_ip
 
@@ -2230,8 +2231,9 @@ contains
                 call exitError('getAndWriteScatterMatrixElementsOrOverlaps',&
                   'Index '//trim(int2str(ibf(iE)))//' not included in optimalPairs file for ik = '//trim(int2str(ikf(iE))),1)
 
-              call calculateBandPairOverlap(ibShift_braket, ibf(iE), ibi(iE), ikf(iE), iki(iE), nSpins, ibBra_optimal, nGVecsLocal, &
-                    volume, readOptimalPairs, spin1Skipped, spin2Skipped, braSys, ketSys, pot, Ufi_iE)
+              call calculateBandPairOverlap(ibShift_braket, ibf(iE), ibi(iE), ikf(iE), iki(iE), nSpins, &
+                    ibBra_optimal(:,ibf(iE)), nGVecsLocal, volume, readOptimalPairs, spin1Skipped, &
+                    spin2Skipped, braSys, ketSys, pot, Ufi_iE)
 
               Ufi(iE,:) = Ufi_iE
 


### PR DESCRIPTION
We previously assumed that the best match between the initial (perfect-crystal) and final (defect-crystal) system were in the same order. However, that is not true. This PR adds the ability to find the optimal matches between bands using the `TME` code, then read the `optimalPairs` from `EnergyTabulator`, `PhononPP`, and `TME` (actual matrix-element calculation) and reshuffle the defect states so that they match the order of the perfect-crystal states. The reshuffling is done so that the `LSF` code only reads output where the states are in the correct order. 